### PR TITLE
Guard event folders + port Rust grouper tests for drive identification

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "electron .",
     "process": "node src/processing/process.js",
-    "test": "node --test src/shared/drive-calc.test.js",
+    "test": "node --test src/shared/drive-calc.test.js src/processing/grouper.test.js",
     "prebuild": "npm test",
     "build": "electron-builder --win",
     "publish": "npm test && electron-builder --win --publish always"

--- a/src/processing/grouper.js
+++ b/src/processing/grouper.js
@@ -55,6 +55,21 @@ function parseFileTimestamp(filePath) {
 // mirrors Sentry-USB-Rusty/crates/drives.
 
 /**
+ * True when a route lives under a top-level SavedClips/ or SentryClips/ event
+ * folder. Mirrors Sentry-USB-Rusty `is_event_folder_path` (grouper.rs:322):
+ * these are parked sentry/event recordings (and path-duplicates of RecentClips
+ * data) that must not be counted as drives. Native scans already skip them
+ * (process.js:91); this is the grouper-level safety net for a loaded or
+ * imported drive-data.json that may still contain them. Only a top-level
+ * segment counts — "MySavedClips/…" and "foo/SavedClips/…" are NOT events.
+ */
+export function isEventFolderPath(file) {
+  if (!file) return false;
+  const norm = String(file).replace(/\\/g, "/");
+  return norm.startsWith("SavedClips/") || norm.startsWith("SentryClips/");
+}
+
+/**
  * Group routes into logical drives based on time gaps and gear state.
  */
 export function groupIntoDrives(routes) {
@@ -63,6 +78,11 @@ export function groupIntoDrives(routes) {
   const seen = new Set();
   const unique = [];
   for (const r of routes) {
+    // Drop SavedClips/SentryClips event-folder routes before dedup — parity
+    // with Rust group_clips (grouper.rs:334). They duplicate RecentClips data
+    // under a path dedup-by-path can't catch and would otherwise surface parked
+    // recordings as spurious drives.
+    if (isEventFolderPath(r.file)) continue;
     const norm = r.file.replace(/\\/g, "/");
     if (!seen.has(norm)) {
       seen.add(norm);

--- a/src/processing/grouper.test.js
+++ b/src/processing/grouper.test.js
@@ -1,0 +1,226 @@
+// Behavioral tests for drive identification — ported from the canonical Rust
+// grouper suite (Sentry-USB-Rusty/crates/drives/src/grouper.rs `#[cfg(test)]`).
+//
+// These run against Drive's real public entry point, groupIntoDrives, which
+// MATERIALIZES the drive list (one drive per group). Where a Rust test targets
+// the server's fast summary-count path, we port its intent against the
+// materialized result and call out the known fast-path-vs-materialized
+// difference (the only one: an all-parked clip → 1 materialized drive here,
+// vs 0 from Rust's 0.6 count-only optimization; Rust's own materialized path
+// also counts it as 1 — see grouper.rs:1774).
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { groupIntoDrives, isEventFolderPath } from './grouper.js';
+import { GEAR_PARK, GEAR_DRIVE } from '../shared/drive-calc.cjs';
+
+// ─── Fixtures (mirror Rust's test_route / park_route / clip_with_gear_runs) ───
+
+function linePoints(n, baseLat = 37.0, baseLng = -122.0) {
+  const pts = [];
+  for (let i = 0; i < n; i++) pts.push([baseLat + i * 1e-4, baseLng]);
+  return pts;
+}
+
+// A normal driving clip with a single GPS point (Rust test_route).
+function testRoute(file, points) {
+  return {
+    file,
+    points,
+    gearStates: [],
+    autopilotStates: [],
+    speeds: [],
+    accelPositions: [],
+    rawParkCount: 0,
+    rawFrameCount: 10,
+    gearRuns: [{ gear: GEAR_DRIVE, frames: 10 }],
+    source: undefined,
+    externalSignature: undefined,
+  };
+}
+
+// A clip parked the entire minute (Rust park_route): 60 Park frames.
+function parkRoute(file, lat) {
+  return {
+    file,
+    points: [[lat, -76.795]],
+    gearStates: [],
+    autopilotStates: [],
+    speeds: [],
+    accelPositions: [],
+    rawParkCount: 60,
+    rawFrameCount: 60,
+    gearRuns: [{ gear: GEAR_PARK, frames: 60 }],
+    source: undefined,
+    externalSignature: undefined,
+  };
+}
+
+// A clip with arbitrary internal gear runs (Rust clip_with_gear_runs). `runs`
+// is [gear, frames] pairs; one GPS point per frame so the frame-fraction
+// slicing in splitClipAtParkGaps maps cleanly to point indices.
+function clipWithGearRuns(file, runs, baseLat = 37.0, baseLng = -122.0) {
+  const totalFrames = runs.reduce((s, [, f]) => s + f, 0);
+  return {
+    file,
+    points: linePoints(Math.max(totalFrames, 1), baseLat, baseLng),
+    gearStates: [],
+    autopilotStates: [],
+    speeds: [],
+    accelPositions: [],
+    rawParkCount: runs.filter(([g]) => g === GEAR_PARK).reduce((s, [, f]) => s + f, 0),
+    rawFrameCount: totalFrames,
+    gearRuns: runs.map(([gear, frames]) => ({ gear, frames })),
+    source: undefined,
+    externalSignature: undefined,
+  };
+}
+
+const drivesOf = (routes) => groupIntoDrives(routes).drives;
+
+// ─── isEventFolderPath (Rust test_is_event_folder_path, grouper.rs:3271) ──────
+
+test('isEventFolderPath: top-level SavedClips/SentryClips only', () => {
+  assert.equal(isEventFolderPath('SavedClips/2026-05-17_18-47-59/2026-05-17_18-47-34-front.mp4'), true);
+  assert.equal(isEventFolderPath('SentryClips/2026-05-17_18-46-39/2026-05-17_18-35-39-front.mp4'), true);
+  // Windows-style separators from a Sentry-Drive drive-data.json import.
+  assert.equal(isEventFolderPath('SavedClips\\2026-05-17_18-47-59\\2026-05-17_18-47-34-front.mp4'), true);
+  assert.equal(isEventFolderPath('SentryClips\\foo\\bar-front.mp4'), true);
+  // Real drive content stays in.
+  assert.equal(isEventFolderPath('RecentClips/2026-05-17/2026-05-17_18-47-34-front.mp4'), false);
+  assert.equal(isEventFolderPath('2026-05-17/2026-05-17_18-47-34-front.mp4'), false);
+  assert.equal(isEventFolderPath('2026-05-17\\2026-05-17_18-47-34-front.mp4'), false);
+  assert.equal(isEventFolderPath(''), false);
+  // Substring matches don't count — must be a top-level segment.
+  assert.equal(isEventFolderPath('foo/SavedClips/x.mp4'), false);
+  assert.equal(isEventFolderPath('MySavedClips/x.mp4'), false);
+});
+
+// ─── Grouping (Rust test_group_clips_*) ───────────────────────────────────────
+
+test('empty input → no drives', () => {
+  assert.equal(drivesOf([]).length, 0);
+});
+
+test('single clip → one drive', () => {
+  const drives = drivesOf([testRoute('/cam/2025-01-15_12-30-45-front.mp4', [[37.0, -122.0]])]);
+  assert.equal(drives.length, 1);
+  assert.equal(drives[0].routeFiles.length, 1);
+});
+
+test('>5 min gap splits into separate drives', () => {
+  const drives = drivesOf([
+    testRoute('/cam/2025-01-15_12-00-00-front.mp4', [[37.0, -122.0]]),
+    testRoute('/cam/2025-01-15_13-00-00-front.mp4', [[37.1, -122.1]]),
+  ]);
+  assert.equal(drives.length, 2);
+});
+
+test('clips <5 min apart stay in one drive', () => {
+  const drives = drivesOf([
+    testRoute('/cam/2025-01-15_12-00-00-front.mp4', [[37.0, -122.0]]),
+    testRoute('/cam/2025-01-15_12-01-00-front.mp4', [[37.0001, -122.0]]),
+  ]);
+  assert.equal(drives.length, 1);
+  assert.equal(drives[0].routeFiles.length, 2);
+});
+
+// ─── Gear-state park splitting (Rust test_split_summary_*) ────────────────────
+
+test('two internal park gaps split one clip into three drives', () => {
+  // 60 frames: drive 20, park 5, drive 15, park 5, drive 15. Park runs are
+  // 5s ≥ PARK_GAP_SECONDS (2s).
+  const drives = drivesOf([
+    clipWithGearRuns('/cam/2025-01-15_12-00-00-front.mp4', [
+      [GEAR_DRIVE, 20], [GEAR_PARK, 5], [GEAR_DRIVE, 15], [GEAR_PARK, 5], [GEAR_DRIVE, 15],
+    ]),
+  ]);
+  assert.equal(drives.length, 3);
+});
+
+test('no internal park gap keeps one drive', () => {
+  const drives = drivesOf([
+    clipWithGearRuns('/cam/2025-01-15_12-00-00-front.mp4', [[GEAR_DRIVE, 60]]),
+  ]);
+  assert.equal(drives.length, 1);
+});
+
+test('all-parked clip → 1 materialized drive', () => {
+  // Drive materializes the all-parked group as a single drive (the
+  // splitByGearState [group] fallback), matching Rust's materialized path
+  // (grouper.rs:1774 "count as 1"). Rust's FAST summary endpoint returns 0
+  // via its 0.6 count-only shortcut — that approximation is not replicated.
+  const drives = drivesOf([
+    clipWithGearRuns('/cam/2025-01-15_12-00-00-front.mp4', [[GEAR_PARK, 60]]),
+  ]);
+  assert.equal(drives.length, 1);
+});
+
+test('a fully-parked clip between two drives yields two drives', () => {
+  const drives = drivesOf([
+    clipWithGearRuns('/cam/2025-01-15_12-00-00-front.mp4', [[GEAR_DRIVE, 60]]),
+    clipWithGearRuns('/cam/2025-01-15_12-01-00-front.mp4', [[GEAR_PARK, 60]]),
+    clipWithGearRuns('/cam/2025-01-15_12-02-00-front.mp4', [[GEAR_DRIVE, 60]]),
+  ]);
+  assert.equal(drives.length, 2);
+  assert.equal(drives[0].routeFiles.length, 1);
+  assert.equal(drives[1].routeFiles.length, 1);
+});
+
+// ─── Dedup + event-folder filtering ──────────────────────────────────────────
+
+test('duplicate file paths (mixed separators) are deduped', () => {
+  const drives = drivesOf([
+    testRoute('cam/2025-01-15_12-00-00-front.mp4', [[37.0, -122.0]]),
+    testRoute('cam\\2025-01-15_12-00-00-front.mp4', [[37.0, -122.0]]),
+  ]);
+  assert.equal(drives.length, 1);
+  assert.equal(drives[0].routeFiles.length, 1);
+});
+
+test('event-folder routes are filtered out of grouping (grouper.rs:3314)', () => {
+  // Three routes in the same minute; only the RecentClips one survives.
+  const drives = drivesOf([
+    testRoute('RecentClips/2025-01-15/2025-01-15_12-30-00-front.mp4', [[37.0, -122.0]]),
+    testRoute('SavedClips/2025-01-15_12-30-30/2025-01-15_12-30-00-front.mp4', [[37.0, -122.0]]),
+    testRoute('SentryClips/2025-01-15_12-29-30/2025-01-15_12-30-00-front.mp4', [[37.0, -122.0]]),
+  ]);
+  assert.equal(drives.length, 1);
+  assert.equal(drives[0].routeFiles.length, 1);
+  assert.equal(drives[0].routeFiles[0].startsWith('RecentClips/'), true);
+});
+
+test('May 17 regression: event clips do not create a phantom parked drive', () => {
+  // 11 SentryClips parked recordings + 1 SavedClips duplicate + 5 RecentClips
+  // driving clips. After event-folder filtering this must be ONE drive of
+  // exactly the 5 RecentClips routes (not a fake parked drive + the trip).
+  const routes = [];
+  for (let minute = 35; minute <= 45; minute++) {
+    const ss = String(39 + (minute - 35)).padStart(2, '0');
+    routes.push(parkRoute(
+      `SentryClips/2026-05-17_18-46-39/2026-05-17_18-${minute}-${ss}-front.mp4`,
+      39.1988 + minute * 1e-6,
+    ));
+  }
+  routes.push(testRoute(
+    'SavedClips/2026-05-17_18-47-59/2026-05-17_18-47-34-front.mp4',
+    [[39.198835, -76.795246]],
+  ));
+  const driveStarts = [
+    'RecentClips/2026-05-17/2026-05-17_18-47-34-front.mp4',
+    'RecentClips/2026-05-17/2026-05-17_18-48-34-front.mp4',
+    'RecentClips/2026-05-17/2026-05-17_18-49-34-front.mp4',
+    'RecentClips/2026-05-17/2026-05-17_18-50-34-front.mp4',
+    'RecentClips/2026-05-17/2026-05-17_18-51-34-front.mp4',
+  ];
+  driveStarts.forEach((f, i) => {
+    routes.push(testRoute(f, [[39.198835 + i * 1e-4, -76.795246]]));
+  });
+
+  const drives = drivesOf(routes);
+  assert.equal(drives.length, 1);
+  assert.equal(drives[0].routeFiles.length, driveStarts.length);
+  for (const f of drives[0].routeFiles) {
+    assert.equal(f.startsWith('RecentClips/'), true);
+  }
+});


### PR DESCRIPTION
Make Drive's drive-identification provably accurate and on par with the canonical Rust grouper (Sentry-USB-Rusty/crates/drives).

- grouper.js: add isEventFolderPath() (mirrors Rust is_event_folder_path, grouper.rs:322) and filter SavedClips/SentryClips routes in groupIntoDrives before dedup. Drive previously excluded event folders only at scan time (process.js:91), leaving the grouper unguarded when loading an external drive-data.json -- which could surface parked Sentry recordings as phantom drives (the May 17 regression).
- grouper.test.js: 12 behavioral tests ported from Rust's grouper suite (empty, single, time-gap split, multi park-gap -> 3 drives, no-park, all-parked, park-between -> 2 drives, dedup, event-folder filtering, and the May 17 regression) run against the real groupIntoDrives. All pass; disabling the guard fails exactly the three guard-dependent tests.
- package.json: include grouper.test.js in the test script (prebuild / publish / CI already run npm test).