### PR TITLE
fix(teslascope): draw imported drives on the map

### DIFF
--- a/src/processing/teslascope-api.cjs
+++ b/src/processing/teslascope-api.cjs
@@ -274,17 +274,21 @@ async function fetchDrivePath(token, publicId, driveId) {
 
 // Pull a GPS point list out of a drive detail, accepting several shapes.
 function extractPoints(detail) {
-  const arr = pickArray(detail, ['path', 'points', 'locations', 'coordinates', 'gps', 'route']);
+  // Teslascope returns the GPS path under `progress`; the other keys cover
+  // alternate response shapes.
+  const arr = pickArray(detail, ['progress', 'path', 'points', 'locations', 'coordinates', 'gps', 'route']);
   return arr
     .map((p) => {
       // Points may be objects or [lat,lng] / [lat,lng,ts] tuples.
       if (Array.isArray(p)) {
-        return { latitude: num(p[0]), longitude: num(p[1]), timestamp: p[2], speed: num(p[3]), autopilot: undefined };
+        return { latitude: num(p[0]), longitude: num(p[1]), timestamp: toMs(p[2]), speed: num(p[3]), autopilot: undefined };
       }
       return {
         latitude: num(pick(p, ['latitude', 'lat'])),
         longitude: num(pick(p, ['longitude', 'lng', 'lon', 'long'])),
-        timestamp: pick(p, ['timestamp', 'time', 'date', 'recorded_at', 't']),
+        // Normalize to epoch ms — `progress` gives ISO strings, but clip-building
+        // expects a numeric timestamp.
+        timestamp: toMs(pick(p, ['timestamp', 'time', 'date', 'recorded_at', 'created_at', 't'])),
         speed: num(pick(p, ['speed', 'speed_mph', 'velocity'])),
         autopilot: pick(p, ['autopilot', 'autopilot_state', 'state', 'ap']),
       };


### PR DESCRIPTION
## Problem
Teslascope-imported drives weren't drawing routes on the map.

1. The drive-detail GPS path comes back under the `progress` key, but `extractPoints()` only looked for `path`/`points`/`coordinates`/etc., so it extracted **zero** points.
2. When points *were* present, their timestamps were ISO strings (`created_at`). `buildClipsForApiDrive` does `ts > 1e12 ? ts : ts*1000`, so a string became `NaN` → clips got NaN time windows → drives skipped as **"no valid time windows."**

## Fix
- Add `progress` to the point-source keys in `extractPoints()`.
- Normalize point timestamps to epoch ms via `toMs()` (and accept `created_at`).

Builds on the recent `normalizeDrive` improvements (created_at/duration, coords, FSD) — this completes the chain so the routes actually render.

## Verification
- Full chain (`normalizeDrive` → `buildClipsForApiDrive`) now builds valid clips with numeric timestamps.
- `npm test` → 48/48 pass.
- Confirmed live: re-imported Teslascope drives draw routes on the map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)