### PR TITLE
perf: defer off-screen drive cards with content-visibility

### DIFF
--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -568,6 +568,11 @@ input[type="date"].text-input::-webkit-calendar-picker-indicator:hover { opacity
   transition: border-color 0.15s, background 0.15s;
   flex-shrink: 0;
   scroll-margin-top: 44px;
+  /* Skip layout/paint for off-screen cards so large histories (1000s of drives)
+     stay responsive while every card stays in the DOM. contain-intrinsic-size is
+     a placeholder height for unrendered cards; `auto` remembers the real size. */
+  content-visibility: auto;
+  contain-intrinsic-size: auto 140px;
 }
 .drive-item:hover {
   border-color: rgba(96, 165, 250, 0.45);


### PR DESCRIPTION
## Problem
With large drive histories (1000s of drives) the entire drive list renders into the DOM (~240k nodes at ~8,500 drives), so the browser re-lays-out all of them on every map pan/scroll → ~1 FPS.

## Fix
`content-visibility: auto` (+ `contain-intrinsic-size`) on `.drive-item` lets the browser skip layout/paint for **off-screen** cards while keeping every card (and its listeners/selection) in the DOM. Pure CSS, no JS — identical on Windows/macOS/Linux.

## Verification
Measured on a ~8,500-drive history: map pan **~1 FPS → ~31 FPS**. All cards stay in the DOM (selection/filters/clicks unaffected). `npm test` → 48/48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)