### PR TITLE
Privacy zones, drive multi-select, and map/UI polish (v1.4.2)

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,13 +1,61 @@
 {
   "versions": [
     {
+      "version": "1.4.2",
+      "date": "2026-07-25",
+      "title": "Privacy Zones, Multi-Select & Map Polish",
+      "changes": [
+        {
+          "type": "improvement",
+          "description": "Removing a drive, removing imported drives, and reverting to a backup no longer look like a freeze — the loading spinner now stays up while the drive data file is rewritten and the list refreshes."
+        },
+        {
+          "type": "feature",
+          "description": "You can now see which drives were bridged by Check Drives: bridged drives carry an amber \"Bridged\" chip on their card, and the completion summary lists the affected drives."
+        },
+        {
+          "type": "improvement",
+          "description": "The update button in the footer now animates while an update downloads, and turns orange and flashes once the download is finished and a restart is needed — so it's obvious at a glance which stage you're at."
+        },
+        {
+          "type": "improvement",
+          "description": "Privacy zone markers can wear any of 20 icons — click the icon on a zone row in Settings > Privacy to pick from a Material Symbols grid (school, gym, restaurant, church, park, and more). The chosen icon shows on the zone's map marker."
+        },
+        {
+          "type": "fix",
+          "description": "The letters on the FSD event markers (A and D) now sit truly centered in their circles — their position is measured from the font's actual glyph bounds on both axes instead of approximated."
+        },
+        {
+          "type": "improvement",
+          "description": "Location labels on drive cards are more accurate: lookups now only match real addresses and businesses, and a business name or house number is used only when it is verifiably at the drive's coordinates — otherwise the label falls back to the street instead of naming the wrong building. Existing labels refresh automatically over time."
+        },
+        {
+          "type": "feature",
+          "description": "Multi-select in the drive list: Ctrl+click toggles drives, Shift+click selects a range, and Esc clears. A floating bar shows the selection count with Remove — deleting the whole batch in one pass with a single confirmation, instead of one drive at a time."
+        },
+        {
+          "type": "feature",
+          "description": "Privacy zones: the new Settings > Privacy tab lets you draw a circle around Home, Work, or any custom location, then cull every drive that starts or ends inside it in one confirmed sweep. Placement is visual — a preview circle follows your cursor while the map pans normally, a click drops the pin, then drag the pin to move the zone or grab anywhere on the circle's edge to resize it before Save/Cancel confirms. Editing a placed zone reopens the same on-map editor, and zone markers stay visible on the map as landmarks. Zones are stored only on this device, never in your drive data file."
+        }
+      ]
+    },
+    {
       "version": "1.4.1",
       "date": "2026-07-15",
       "title": "Maintenance Update",
       "changes": [
-        { "type": "improvement", "description": "Updated the app to the latest Electron runtime (newer Chromium and Node under the hood) for up-to-date security and platform fixes." },
-        { "type": "improvement", "description": "Refreshed the libraries that read and process your drive data to their latest versions." },
-        { "type": "improvement", "description": "One small side effect of the runtime update: file-picker dialogs (like the Import browsers) may now start in your Downloads folder instead of the last folder you used." }
+        {
+          "type": "improvement",
+          "description": "Updated the app to the latest Electron runtime (newer Chromium and Node under the hood) for up-to-date security and platform fixes."
+        },
+        {
+          "type": "improvement",
+          "description": "Refreshed the libraries that read and process your drive data to their latest versions."
+        },
+        {
+          "type": "improvement",
+          "description": "One small side effect of the runtime update: file-picker dialogs (like the Import browsers) may now start in your Downloads folder instead of the last folder you used."
+        }
       ]
     },
     {
@@ -15,14 +63,38 @@
       "date": "2026-07-01",
       "title": "Green Theme, Vehicle Markers & Customization",
       "changes": [
-        { "type": "feature", "description": "Import Drives can now merge another Sentry Drive drive-data.json into your current data — a backup, or drives from a second device. Pick \"Drive Data File\" in the Import dialog; clips you already have are skipped and each imported drive brings its tags along. The drives fold in as regular drives — including their FSD and Autopilot data — so the app confirms first, since this can change your FSD score. A backup of your file is written before merging." },
-        { "type": "improvement", "description": "The app's accent color is now Sentry USB green to match the rest of the Sentry ecosystem — buttons, tabs, highlights, and the ambient glow. The Settings panel also picks up the frosted-glass look. Map drive lines keep their existing colors (they indicate drive type)." },
-        { "type": "improvement", "description": "The support log is now a proper activity timeline — it records loads, imports, processing runs (with outcome counts and timing), drive edits, and update checks, tagged by area. Exported logs are automatically scrubbed of GPS coordinates, addresses, and tokens so they're safe to share in bug reports, and the Logs setting carries a short privacy reminder. Settings labels are also larger and easier to read." },
-        { "type": "improvement", "description": "Drive replay polish: pick a playback speed from a pop-up list instead of clicking to cycle through 1x/2x/5x/10x, and the FSD event markers on the map now have bigger, centered white letters (A for accelerator override, D for disengagement) with a more legible amber for accelerator presses." },
-        { "type": "feature", "description": "Drive line colors are now customizable. Settings > Map UI > Customization has color swatches for Manual, Full Self-Driving, Imported, and the all-drives overview, with a reset to defaults. The map legend and FSD share bars follow your chosen colors, and changes apply live — even mid-replay." },
-        { "type": "feature", "description": "The replay marker adds Model Y and Model X as vehicle styles alongside Model 3, with the same custom paint color and preview. Model S and Cybertruck are wired in as well and will appear in the list automatically once their artwork ships." },
-        { "type": "improvement", "description": "Accent text is easier to read: green labels (View Drives, Check Drives, chips, badges, links) now use the same emerald as Sentry USB instead of a paler tint, and Load Drives, Revert, and Remove Imported Drives join the emerald set — the destructive pair still turns red on hover as a warning." },
-        { "type": "fix", "description": "The Import Drives dialog can no longer get stuck on \"Importing…\" if an unexpected error interrupts the import — it now reports the error and re-enables the button." }
+        {
+          "type": "feature",
+          "description": "Import Drives can now merge another Sentry Drive drive-data.json into your current data — a backup, or drives from a second device. Pick \"Drive Data File\" in the Import dialog; clips you already have are skipped and each imported drive brings its tags along. The drives fold in as regular drives — including their FSD and Autopilot data — so the app confirms first, since this can change your FSD score. A backup of your file is written before merging."
+        },
+        {
+          "type": "improvement",
+          "description": "The app's accent color is now Sentry USB green to match the rest of the Sentry ecosystem — buttons, tabs, highlights, and the ambient glow. The Settings panel also picks up the frosted-glass look. Map drive lines keep their existing colors (they indicate drive type)."
+        },
+        {
+          "type": "improvement",
+          "description": "The support log is now a proper activity timeline — it records loads, imports, processing runs (with outcome counts and timing), drive edits, and update checks, tagged by area. Exported logs are automatically scrubbed of GPS coordinates, addresses, and tokens so they're safe to share in bug reports, and the Logs setting carries a short privacy reminder. Settings labels are also larger and easier to read."
+        },
+        {
+          "type": "improvement",
+          "description": "Drive replay polish: pick a playback speed from a pop-up list instead of clicking to cycle through 1x/2x/5x/10x, and the FSD event markers on the map now have bigger, centered white letters (A for accelerator override, D for disengagement) with a more legible amber for accelerator presses."
+        },
+        {
+          "type": "feature",
+          "description": "Drive line colors are now customizable. Settings > Map UI > Customization has color swatches for Manual, Full Self-Driving, Imported, and the all-drives overview, with a reset to defaults. The map legend and FSD share bars follow your chosen colors, and changes apply live — even mid-replay."
+        },
+        {
+          "type": "feature",
+          "description": "The replay marker adds Model Y and Model X as vehicle styles alongside Model 3, with the same custom paint color and preview. Model S and Cybertruck are wired in as well and will appear in the list automatically once their artwork ships."
+        },
+        {
+          "type": "improvement",
+          "description": "Accent text is easier to read: green labels (View Drives, Check Drives, chips, badges, links) now use the same emerald as Sentry USB instead of a paler tint, and Load Drives, Revert, and Remove Imported Drives join the emerald set — the destructive pair still turns red on hover as a warning."
+        },
+        {
+          "type": "fix",
+          "description": "The Import Drives dialog can no longer get stuck on \"Importing…\" if an unexpected error interrupts the import — it now reports the error and re-enables the button."
+        }
       ]
     },
     {
@@ -30,12 +102,30 @@
       "date": "2026-06-15",
       "title": "Corruption Hardening, Smoother Imports & Auto-Refresh",
       "changes": [
-        { "type": "feature", "description": "The app now auto-refreshes when drive-data.json changes on disk — for example when Sentry USB re-exports it or processing finishes — so you no longer have to reload manually. It waits politely if you're viewing a drive or processing, then refreshes when you're done." },
-        { "type": "improvement", "description": "Saving your drive data is now hardened against corruption: every write is flushed to disk and integrity-checked before it replaces the real file, so a power loss, full disk, or dropped network drive mid-save can no longer leave you with a truncated drive-data.json — the previous good copy is kept instead." },
-        { "type": "improvement", "description": "Importing drives feels much smoother on large drive libraries: the save step now shows live progress instead of appearing frozen, and the import no longer re-scans your existing drives twice per run." },
-        { "type": "improvement", "description": "The drive list no longer freezes the app while it builds after a large import or reload — it now fills in progressively and the window stays responsive." },
-        { "type": "improvement", "description": "The FSD Score now shows one decimal place and rounds down (e.g. 99.8% instead of 100%), so a near-perfect score is no longer flattered up to a perfect one." },
-        { "type": "fix", "description": "Adding or removing a tag from the drive stats panel now updates the panel right away — it previously saved the tag but didn't show it there until you reselected the drive." }
+        {
+          "type": "feature",
+          "description": "The app now auto-refreshes when drive-data.json changes on disk — for example when Sentry USB re-exports it or processing finishes — so you no longer have to reload manually. It waits politely if you're viewing a drive or processing, then refreshes when you're done."
+        },
+        {
+          "type": "improvement",
+          "description": "Saving your drive data is now hardened against corruption: every write is flushed to disk and integrity-checked before it replaces the real file, so a power loss, full disk, or dropped network drive mid-save can no longer leave you with a truncated drive-data.json — the previous good copy is kept instead."
+        },
+        {
+          "type": "improvement",
+          "description": "Importing drives feels much smoother on large drive libraries: the save step now shows live progress instead of appearing frozen, and the import no longer re-scans your existing drives twice per run."
+        },
+        {
+          "type": "improvement",
+          "description": "The drive list no longer freezes the app while it builds after a large import or reload — it now fills in progressively and the window stays responsive."
+        },
+        {
+          "type": "improvement",
+          "description": "The FSD Score now shows one decimal place and rounds down (e.g. 99.8% instead of 100%), so a near-perfect score is no longer flattered up to a perfect one."
+        },
+        {
+          "type": "fix",
+          "description": "Adding or removing a tag from the drive stats panel now updates the panel right away — it previously saved the tag but didn't show it there until you reselected the drive."
+        }
       ]
     },
     {
@@ -43,9 +133,18 @@
       "date": "2026-06-15",
       "title": "Auto-Refresh, FSD Score Precision & Tag Fix",
       "changes": [
-        { "type": "feature", "description": "The app now auto-refreshes when drive-data.json changes on disk — for example when Sentry USB re-exports it or processing finishes — so you no longer have to reload manually. It waits politely if you're viewing a drive or processing, then refreshes when you're done." },
-        { "type": "improvement", "description": "The FSD Score now shows one decimal place and rounds down (e.g. 99.8% instead of 100%), so a near-perfect score is no longer flattered up to a perfect one." },
-        { "type": "fix", "description": "Adding or removing a tag from the drive stats panel now updates the panel right away — it previously saved the tag but didn't show it there until you reselected the drive." }
+        {
+          "type": "feature",
+          "description": "The app now auto-refreshes when drive-data.json changes on disk — for example when Sentry USB re-exports it or processing finishes — so you no longer have to reload manually. It waits politely if you're viewing a drive or processing, then refreshes when you're done."
+        },
+        {
+          "type": "improvement",
+          "description": "The FSD Score now shows one decimal place and rounds down (e.g. 99.8% instead of 100%), so a near-perfect score is no longer flattered up to a perfect one."
+        },
+        {
+          "type": "fix",
+          "description": "Adding or removing a tag from the drive stats panel now updates the panel right away — it previously saved the tag but didn't show it there until you reselected the drive."
+        }
       ]
     },
     {
@@ -53,9 +152,18 @@
       "date": "2026-06-13",
       "title": "Drive Data Corruption Hardening & Smoother Imports",
       "changes": [
-        { "type": "improvement", "description": "Saving your drive data is now hardened against corruption: every write is flushed to disk and integrity-checked before it replaces the real file, so a power loss, full disk, or dropped network drive mid-save can no longer leave you with a truncated drive-data.json — the previous good copy is kept instead." },
-        { "type": "improvement", "description": "Importing drives feels much smoother on large drive libraries: the save step now shows live progress instead of appearing frozen, and the import no longer re-scans your existing drives twice per run." },
-        { "type": "improvement", "description": "The drive list no longer freezes the app while it builds after a large import or reload — it now fills in progressively and the window stays responsive." }
+        {
+          "type": "improvement",
+          "description": "Saving your drive data is now hardened against corruption: every write is flushed to disk and integrity-checked before it replaces the real file, so a power loss, full disk, or dropped network drive mid-save can no longer leave you with a truncated drive-data.json — the previous good copy is kept instead."
+        },
+        {
+          "type": "improvement",
+          "description": "Importing drives feels much smoother on large drive libraries: the save step now shows live progress instead of appearing frozen, and the import no longer re-scans your existing drives twice per run."
+        },
+        {
+          "type": "improvement",
+          "description": "The drive list no longer freezes the app while it builds after a large import or reload — it now fills in progressively and the window stays responsive."
+        }
       ]
     },
     {
@@ -63,7 +171,10 @@
       "date": "2026-06-13",
       "title": "Universal Drive Stats (Sentry USB Parity)",
       "changes": [
-        { "type": "fix", "description": "A clip where the car only sat parked (no movement) is no longer counted as a zero-mile drive, matching Sentry USB exactly so the two apps report the same lifetime drive count and total time. Your count and time may tick down slightly; distance is unaffected." }
+        {
+          "type": "fix",
+          "description": "A clip where the car only sat parked (no movement) is no longer counted as a zero-mile drive, matching Sentry USB exactly so the two apps report the same lifetime drive count and total time. Your count and time may tick down slightly; distance is unaffected."
+        }
       ]
     },
     {
@@ -71,10 +182,22 @@
       "date": "2026-06-12",
       "title": "Processing Reliability & Hardening",
       "changes": [
-        { "type": "fix", "description": "Fixed a crash at the end of processing (\"ENOENT: no such file or directory, rename ... drive-data.json.tmp\") — a progress checkpoint still writing when processing finished could collide with the final save, killing the run and potentially corrupting drive-data.json. Checkpoints and the final save are now strictly ordered and never share files. If a previous run hit this, simply process again." },
-        { "type": "fix", "description": "Place names and tags are now safely escaped in the drive list — a location label or tag containing HTML characters could break the card layout or be interpreted as markup." },
-        { "type": "improvement", "description": "Processing sweeps leftover temporary files from previously crashed or interrupted runs." },
-        { "type": "fix", "description": "Processing no longer attempts a leftover debug copy of drive-data.json to a developer's local path at the end of every run." }
+        {
+          "type": "fix",
+          "description": "Fixed a crash at the end of processing (\"ENOENT: no such file or directory, rename ... drive-data.json.tmp\") — a progress checkpoint still writing when processing finished could collide with the final save, killing the run and potentially corrupting drive-data.json. Checkpoints and the final save are now strictly ordered and never share files. If a previous run hit this, simply process again."
+        },
+        {
+          "type": "fix",
+          "description": "Place names and tags are now safely escaped in the drive list — a location label or tag containing HTML characters could break the card layout or be interpreted as markup."
+        },
+        {
+          "type": "improvement",
+          "description": "Processing sweeps leftover temporary files from previously crashed or interrupted runs."
+        },
+        {
+          "type": "fix",
+          "description": "Processing no longer attempts a leftover debug copy of drive-data.json to a developer's local path at the end of every run."
+        }
       ]
     },
     {
@@ -82,10 +205,22 @@
       "date": "2026-06-12",
       "title": "Battery on Drive Cards & Replay Progress Trail",
       "changes": [
-        { "type": "feature", "description": "Drive cards now show the battery charge beside Departed and Arrived when your Sentry USB device recorded it — available on drives captured since its BLE vehicle-data update. Older history and imported drives simply omit it." },
-        { "type": "feature", "description": "Drive replay paints progress along the route — the path ahead of the marker is dimmed and takes on its normal color as the marker passes. Scrubbing moves the boundary both ways, and the FSD green/manual blue segments stay distinct in both states." },
-        { "type": "improvement", "description": "Map UI settings: city labels and road labels now have separate toggles, and the old \"Hide other drives\" checkbox is now the clearer \"Show other drives when viewing a drive\"." },
-        { "type": "improvement", "description": "City and street labels now draw above the drive lines, so place names stay readable over dense route areas on every map layer." }
+        {
+          "type": "feature",
+          "description": "Drive cards now show the battery charge beside Departed and Arrived when your Sentry USB device recorded it — available on drives captured since its BLE vehicle-data update. Older history and imported drives simply omit it."
+        },
+        {
+          "type": "feature",
+          "description": "Drive replay paints progress along the route — the path ahead of the marker is dimmed and takes on its normal color as the marker passes. Scrubbing moves the boundary both ways, and the FSD green/manual blue segments stay distinct in both states."
+        },
+        {
+          "type": "improvement",
+          "description": "Map UI settings: city labels and road labels now have separate toggles, and the old \"Hide other drives\" checkbox is now the clearer \"Show other drives when viewing a drive\"."
+        },
+        {
+          "type": "improvement",
+          "description": "City and street labels now draw above the drive lines, so place names stay readable over dense route areas on every map layer."
+        }
       ]
     },
     {
@@ -93,9 +228,18 @@
       "date": "2026-06-11",
       "title": "Map Overview Readability",
       "changes": [
-        { "type": "improvement", "description": "Imported drives no longer drown out dashcam drives on the map overview — they draw underneath, fainter and thinner, so your recorded drive lines stay readable." },
-        { "type": "improvement", "description": "Drive lines on the overview are slightly thicker — easier to see and easier to click." },
-        { "type": "improvement", "description": "Street names are now shown on all map layers — Light, Dark, and Satellite — with a new \"Show road labels\" toggle in Map UI, independent of the city-labels toggle." }
+        {
+          "type": "improvement",
+          "description": "Imported drives no longer drown out dashcam drives on the map overview — they draw underneath, fainter and thinner, so your recorded drive lines stay readable."
+        },
+        {
+          "type": "improvement",
+          "description": "Drive lines on the overview are slightly thicker — easier to see and easier to click."
+        },
+        {
+          "type": "improvement",
+          "description": "Street names are now shown on all map layers — Light, Dark, and Satellite — with a new \"Show road labels\" toggle in Map UI, independent of the city-labels toggle."
+        }
       ]
     },
     {
@@ -103,19 +247,58 @@
       "date": "2026-06-11",
       "title": "GPU Map Engine, Smarter Imports & Replay Accuracy",
       "changes": [
-        { "type": "feature", "description": "The map runs on a new GPU-accelerated engine (MapLibre GL) — panning and zooming stay smooth even with thousands of drive lines on screen. Same Google map styles, layers, and labels; clicking, replay, and the legend all work as before." },
-        { "type": "fix", "description": "Dropdowns work again — the Service and Vehicle pickers in Import Drives and the marker picker in Settings wouldn't open (a Chromium quirk with the frosted-glass blur on modals; the glass look is unchanged)." },
-        { "type": "fix", "description": "Clicking a drive line on the map overview works again — selecting a drive from the map had stopped working — and lines now accept clicks within a comfortable distance instead of needing a pixel-perfect hit." },
-        { "type": "fix", "description": "The replay arrow keeps tracking at parking speeds — below ~5 mph, while reversing, and through back-in maneuvers it no longer freezes or swings to a direction the car never faced. Replaying a finished drive snaps the arrow back to the departure heading." },
-        { "type": "improvement", "description": "Import Drives no longer queries the service in the background — nothing is fetched while you adjust dates or pick a vehicle. Clicking Import runs the check first, shows what was found, and stops safely if there's nothing new." },
-        { "type": "feature", "description": "The replay bar now shows the current gear (P / D / R / N), and speed reads correctly while reversing." },
-        { "type": "feature", "description": "Remove Imported Drives lets you choose which service to clean out — Tessie, Teslascope, or both — and reports the real number of drives removed (it previously counted internal clips, e.g. \"339\" for 25 drives). It also explains when removed drives were hidden behind dashcam drives." },
-        { "type": "improvement", "description": "Drive locations fall back to the city when no street address exists at a spot, instead of showing raw GPS coordinates." },
-        { "type": "improvement", "description": "Buttons across the app now match the Liquid Glass design — translucent blue primary buttons and frosted glass secondary tiles." },
-        { "type": "improvement", "description": "FSD analytics: Autopilot now uses Tesla's signature blue, and the donut chart center is fully transparent so the map shows through." },
-        { "type": "improvement", "description": "The aggregate stats panel always stays on one line, compressing spacing and text on narrow windows instead of wrapping." },
-        { "type": "improvement", "description": "The app now opens on View Drives instead of Processing, with a new route icon next to the title." },
-        { "type": "improvement", "description": "Integration cards have clearer descriptions, both services link with \"Get API key\", and the Teslascope link opens the correct page (Account → Security)." }
+        {
+          "type": "feature",
+          "description": "The map runs on a new GPU-accelerated engine (MapLibre GL) — panning and zooming stay smooth even with thousands of drive lines on screen. Same Google map styles, layers, and labels; clicking, replay, and the legend all work as before."
+        },
+        {
+          "type": "fix",
+          "description": "Dropdowns work again — the Service and Vehicle pickers in Import Drives and the marker picker in Settings wouldn't open (a Chromium quirk with the frosted-glass blur on modals; the glass look is unchanged)."
+        },
+        {
+          "type": "fix",
+          "description": "Clicking a drive line on the map overview works again — selecting a drive from the map had stopped working — and lines now accept clicks within a comfortable distance instead of needing a pixel-perfect hit."
+        },
+        {
+          "type": "fix",
+          "description": "The replay arrow keeps tracking at parking speeds — below ~5 mph, while reversing, and through back-in maneuvers it no longer freezes or swings to a direction the car never faced. Replaying a finished drive snaps the arrow back to the departure heading."
+        },
+        {
+          "type": "improvement",
+          "description": "Import Drives no longer queries the service in the background — nothing is fetched while you adjust dates or pick a vehicle. Clicking Import runs the check first, shows what was found, and stops safely if there's nothing new."
+        },
+        {
+          "type": "feature",
+          "description": "The replay bar now shows the current gear (P / D / R / N), and speed reads correctly while reversing."
+        },
+        {
+          "type": "feature",
+          "description": "Remove Imported Drives lets you choose which service to clean out — Tessie, Teslascope, or both — and reports the real number of drives removed (it previously counted internal clips, e.g. \"339\" for 25 drives). It also explains when removed drives were hidden behind dashcam drives."
+        },
+        {
+          "type": "improvement",
+          "description": "Drive locations fall back to the city when no street address exists at a spot, instead of showing raw GPS coordinates."
+        },
+        {
+          "type": "improvement",
+          "description": "Buttons across the app now match the Liquid Glass design — translucent blue primary buttons and frosted glass secondary tiles."
+        },
+        {
+          "type": "improvement",
+          "description": "FSD analytics: Autopilot now uses Tesla's signature blue, and the donut chart center is fully transparent so the map shows through."
+        },
+        {
+          "type": "improvement",
+          "description": "The aggregate stats panel always stays on one line, compressing spacing and text on narrow windows instead of wrapping."
+        },
+        {
+          "type": "improvement",
+          "description": "The app now opens on View Drives instead of Processing, with a new route icon next to the title."
+        },
+        {
+          "type": "improvement",
+          "description": "Integration cards have clearer descriptions, both services link with \"Get API key\", and the Teslascope link opens the correct page (Account → Security)."
+        }
       ]
     },
     {
@@ -123,16 +306,46 @@
       "date": "2026-06-11",
       "title": "Replay Accuracy, Map Clicks & Liquid Glass Polish",
       "changes": [
-        { "type": "fix", "description": "Clicking a drive line on the map overview works again — selecting a drive from the map had stopped working — and lines now accept clicks within a comfortable distance instead of needing a pixel-perfect hit." },
-        { "type": "fix", "description": "The replay arrow keeps tracking at parking speeds — below ~5 mph, while reversing, and through back-in maneuvers it no longer freezes or swings to a direction the car never faced. Replaying a finished drive snaps the arrow back to the departure heading." },
-        { "type": "feature", "description": "The replay bar now shows the current gear (P / D / R / N), and speed reads correctly while reversing." },
-        { "type": "feature", "description": "Remove Imported Drives lets you choose which service to clean out — Tessie, Teslascope, or both — and reports the real number of drives removed (it previously counted internal clips, e.g. \"339\" for 25 drives). It also explains when removed drives were hidden behind dashcam drives." },
-        { "type": "improvement", "description": "Drive locations fall back to the city when no street address exists at a spot, instead of showing raw GPS coordinates." },
-        { "type": "improvement", "description": "Buttons across the app now match the Liquid Glass design — translucent blue primary buttons and frosted glass secondary tiles." },
-        { "type": "improvement", "description": "FSD analytics: Autopilot now uses Tesla's signature blue, and the donut chart center is fully transparent so the map shows through." },
-        { "type": "improvement", "description": "The aggregate stats panel always stays on one line, compressing spacing and text on narrow windows instead of wrapping." },
-        { "type": "improvement", "description": "The app now opens on View Drives instead of Processing, with a new route icon next to the title." },
-        { "type": "improvement", "description": "Integration cards have clearer descriptions, both services link with \"Get API key\", and the Teslascope link opens the correct page (Account → Security)." }
+        {
+          "type": "fix",
+          "description": "Clicking a drive line on the map overview works again — selecting a drive from the map had stopped working — and lines now accept clicks within a comfortable distance instead of needing a pixel-perfect hit."
+        },
+        {
+          "type": "fix",
+          "description": "The replay arrow keeps tracking at parking speeds — below ~5 mph, while reversing, and through back-in maneuvers it no longer freezes or swings to a direction the car never faced. Replaying a finished drive snaps the arrow back to the departure heading."
+        },
+        {
+          "type": "feature",
+          "description": "The replay bar now shows the current gear (P / D / R / N), and speed reads correctly while reversing."
+        },
+        {
+          "type": "feature",
+          "description": "Remove Imported Drives lets you choose which service to clean out — Tessie, Teslascope, or both — and reports the real number of drives removed (it previously counted internal clips, e.g. \"339\" for 25 drives). It also explains when removed drives were hidden behind dashcam drives."
+        },
+        {
+          "type": "improvement",
+          "description": "Drive locations fall back to the city when no street address exists at a spot, instead of showing raw GPS coordinates."
+        },
+        {
+          "type": "improvement",
+          "description": "Buttons across the app now match the Liquid Glass design — translucent blue primary buttons and frosted glass secondary tiles."
+        },
+        {
+          "type": "improvement",
+          "description": "FSD analytics: Autopilot now uses Tesla's signature blue, and the donut chart center is fully transparent so the map shows through."
+        },
+        {
+          "type": "improvement",
+          "description": "The aggregate stats panel always stays on one line, compressing spacing and text on narrow windows instead of wrapping."
+        },
+        {
+          "type": "improvement",
+          "description": "The app now opens on View Drives instead of Processing, with a new route icon next to the title."
+        },
+        {
+          "type": "improvement",
+          "description": "Integration cards have clearer descriptions, both services link with \"Get API key\", and the Teslascope link opens the correct page (Account → Security)."
+        }
       ]
     },
     {
@@ -140,22 +353,70 @@
       "date": "2026-06-11",
       "title": "Teslascope Import, Linux Support & Major Accuracy Upgrades",
       "changes": [
-        { "type": "fix", "description": "Fixed drives failing to load in 1.2.0 (\"Identifier 'isEventFolderPath' has already been declared\")." },
-        { "type": "feature", "description": "Teslascope import works end-to-end — connect with the API key from Account → Security, and your full drive history imports with route lines, verified against live data." },
-        { "type": "feature", "description": "Linux support — releases now include an AppImage (with the same auto-update as Windows) and a .deb package." },
-        { "type": "feature", "description": "Redesigned map layers — Light and Dark are now both Google Maps, decluttered to show only city and neighborhood labels alongside your drive lines. Dark uses Google's full night palette with parks, buildings, transit, and light-grey highways; Satellite gains the same labels; a Settings toggle hides labels entirely; Light is the new default." },
-        { "type": "feature", "description": "New Support tab in Settings — save app logs as a text file to attach to bug reports. Logs survive crashes and include the previous session." },
-        { "type": "improvement", "description": "Drive data loads dramatically faster — large files that took a minute now open in seconds." },
-        { "type": "improvement", "description": "Drive locations are more accurate — your car's own reported address is used when available, and the GPS-based lookup is much more precise for everything else. Addresses may quietly update once after installing." },
-        { "type": "improvement", "description": "Drive durations are now frame-accurate — a drive that stops partway through its final minute no longer counts the whole minute, matching Sentry USB's totals (expect your lifetime duration to drop slightly)." },
-        { "type": "fix", "description": "The replay arrow now reliably faces the direction of travel — no more random swings while stopped — and scrubbing the timeline always points it the way the car was facing at that moment." },
-        { "type": "improvement", "description": "The selected drive now draws on top of the other drive lines on the map." },
-        { "type": "improvement", "description": "Tessie and Teslascope drive lines render smoothly instead of angular (display only — stats still use the raw recorded points), and the FSD Score now counts only dashcam-recorded drives so imported drives can't dilute it." },
-        { "type": "improvement", "description": "The Import Drives dialog is much more responsive — vehicles appear instantly when switching services, date fields open a calendar picker, and the preview explains exactly why any drives were skipped." },
-        { "type": "improvement", "description": "\"Check for Update\" clearly shows what it's doing, and the corner download button pulses yellow when an update is waiting." },
-        { "type": "improvement", "description": "Processing large clip libraries is faster, an interrupted run can no longer corrupt your drive data, and saving tags or importing no longer fails on very large files." },
-        { "type": "improvement", "description": "The app works fully offline (except live map tiles) — the map framework, fonts, and icons now ship with the app. Typography is unified on Noto Sans." },
-        { "type": "improvement", "description": "Scrolling and map panning stay smooth with histories of thousands of drives." }
+        {
+          "type": "fix",
+          "description": "Fixed drives failing to load in 1.2.0 (\"Identifier 'isEventFolderPath' has already been declared\")."
+        },
+        {
+          "type": "feature",
+          "description": "Teslascope import works end-to-end — connect with the API key from Account → Security, and your full drive history imports with route lines, verified against live data."
+        },
+        {
+          "type": "feature",
+          "description": "Linux support — releases now include an AppImage (with the same auto-update as Windows) and a .deb package."
+        },
+        {
+          "type": "feature",
+          "description": "Redesigned map layers — Light and Dark are now both Google Maps, decluttered to show only city and neighborhood labels alongside your drive lines. Dark uses Google's full night palette with parks, buildings, transit, and light-grey highways; Satellite gains the same labels; a Settings toggle hides labels entirely; Light is the new default."
+        },
+        {
+          "type": "feature",
+          "description": "New Support tab in Settings — save app logs as a text file to attach to bug reports. Logs survive crashes and include the previous session."
+        },
+        {
+          "type": "improvement",
+          "description": "Drive data loads dramatically faster — large files that took a minute now open in seconds."
+        },
+        {
+          "type": "improvement",
+          "description": "Drive locations are more accurate — your car's own reported address is used when available, and the GPS-based lookup is much more precise for everything else. Addresses may quietly update once after installing."
+        },
+        {
+          "type": "improvement",
+          "description": "Drive durations are now frame-accurate — a drive that stops partway through its final minute no longer counts the whole minute, matching Sentry USB's totals (expect your lifetime duration to drop slightly)."
+        },
+        {
+          "type": "fix",
+          "description": "The replay arrow now reliably faces the direction of travel — no more random swings while stopped — and scrubbing the timeline always points it the way the car was facing at that moment."
+        },
+        {
+          "type": "improvement",
+          "description": "The selected drive now draws on top of the other drive lines on the map."
+        },
+        {
+          "type": "improvement",
+          "description": "Tessie and Teslascope drive lines render smoothly instead of angular (display only — stats still use the raw recorded points), and the FSD Score now counts only dashcam-recorded drives so imported drives can't dilute it."
+        },
+        {
+          "type": "improvement",
+          "description": "The Import Drives dialog is much more responsive — vehicles appear instantly when switching services, date fields open a calendar picker, and the preview explains exactly why any drives were skipped."
+        },
+        {
+          "type": "improvement",
+          "description": "\"Check for Update\" clearly shows what it's doing, and the corner download button pulses yellow when an update is waiting."
+        },
+        {
+          "type": "improvement",
+          "description": "Processing large clip libraries is faster, an interrupted run can no longer corrupt your drive data, and saving tags or importing no longer fails on very large files."
+        },
+        {
+          "type": "improvement",
+          "description": "The app works fully offline (except live map tiles) — the map framework, fonts, and icons now ship with the app. Typography is unified on Noto Sans."
+        },
+        {
+          "type": "improvement",
+          "description": "Scrolling and map panning stay smooth with histories of thousands of drives."
+        }
       ]
     },
     {
@@ -163,13 +424,34 @@
       "date": "2026-06-10",
       "title": "Import Polish, Offline Mode & Accurate Durations",
       "changes": [
-        { "type": "fix", "description": "Import Drives — the Import button can no longer be tricked into starting an import the preview said would do nothing (re-clicking the active tab used to enable it), and the preview now explains why drives were skipped instead of just showing \"0 will be imported\"." },
-        { "type": "improvement", "description": "Drive durations are now frame-accurate — a drive that stops partway through its final minute no longer counts the whole minute, matching Sentry USB's totals (expect your lifetime duration to drop slightly)." },
-        { "type": "improvement", "description": "The app now works fully offline (except live map tiles) — the map framework, fonts, and icons ship with the app instead of loading from the internet at launch. Faster startup, no more blank map without a connection, and fewer third-party requests." },
-        { "type": "improvement", "description": "Unified typography — the interface now uses Noto Sans throughout, with Noto Sans Mono for numbers and stats." },
-        { "type": "fix", "description": "Dark map polish — highways are now light grey and stay visible at every zoom (they previously lost their color when zoomed in), and map labels are white for better readability." },
-        { "type": "improvement", "description": "Tessie and Teslascope drive lines render smoothly instead of angular — their sparse GPS breadcrumbs are visually rounded on the map (display only; distances and stats still use the raw recorded points)." },
-        { "type": "fix", "description": "The FSD Score now ignores Teslascope-imported drives, like it already did for Tessie — imported drives carry coarse or missing autopilot data and were diluting the score. Mileage and duration totals still include them." }
+        {
+          "type": "fix",
+          "description": "Import Drives — the Import button can no longer be tricked into starting an import the preview said would do nothing (re-clicking the active tab used to enable it), and the preview now explains why drives were skipped instead of just showing \"0 will be imported\"."
+        },
+        {
+          "type": "improvement",
+          "description": "Drive durations are now frame-accurate — a drive that stops partway through its final minute no longer counts the whole minute, matching Sentry USB's totals (expect your lifetime duration to drop slightly)."
+        },
+        {
+          "type": "improvement",
+          "description": "The app now works fully offline (except live map tiles) — the map framework, fonts, and icons ship with the app instead of loading from the internet at launch. Faster startup, no more blank map without a connection, and fewer third-party requests."
+        },
+        {
+          "type": "improvement",
+          "description": "Unified typography — the interface now uses Noto Sans throughout, with Noto Sans Mono for numbers and stats."
+        },
+        {
+          "type": "fix",
+          "description": "Dark map polish — highways are now light grey and stay visible at every zoom (they previously lost their color when zoomed in), and map labels are white for better readability."
+        },
+        {
+          "type": "improvement",
+          "description": "Tessie and Teslascope drive lines render smoothly instead of angular — their sparse GPS breadcrumbs are visually rounded on the map (display only; distances and stats still use the raw recorded points)."
+        },
+        {
+          "type": "fix",
+          "description": "The FSD Score now ignores Teslascope-imported drives, like it already did for Tessie — imported drives carry coarse or missing autopilot data and were diluting the score. Mileage and duration totals still include them."
+        }
       ]
     },
     {
@@ -177,9 +459,18 @@
       "date": "2026-06-10",
       "title": "Teslascope Import — For Real This Time",
       "changes": [
-        { "type": "fix", "description": "Teslascope drives now actually import — the app now reads Teslascope's real drive format (timestamps, coordinates, distance), verified against live data. Previously every drive was skipped as unreadable." },
-        { "type": "improvement", "description": "Logs now survive crashes — they're written to disk as they happen, and the log export includes the previous session, so whatever happened right before a crash is always recoverable." },
-        { "type": "improvement", "description": "The Dark map now distinguishes more detail — parks render dark green, buildings and built-up areas are distinct at street zooms, transit lines are visible, and highways are distinguished from local roads." }
+        {
+          "type": "fix",
+          "description": "Teslascope drives now actually import — the app now reads Teslascope's real drive format (timestamps, coordinates, distance), verified against live data. Previously every drive was skipped as unreadable."
+        },
+        {
+          "type": "improvement",
+          "description": "Logs now survive crashes — they're written to disk as they happen, and the log export includes the previous session, so whatever happened right before a crash is always recoverable."
+        },
+        {
+          "type": "improvement",
+          "description": "The Dark map now distinguishes more detail — parks render dark green, buildings and built-up areas are distinct at street zooms, transit lines are visible, and highways are distinguished from local roads."
+        }
       ]
     },
     {
@@ -187,7 +478,10 @@
       "date": "2026-06-10",
       "title": "Teslascope Import Fix",
       "changes": [
-        { "type": "fix", "description": "Teslascope import no longer fails with \"The limit may not be greater than 100\" — drives are now fetched 100 at a time through your full history." }
+        {
+          "type": "fix",
+          "description": "Teslascope import no longer fails with \"The limit may not be greater than 100\" — drives are now fetched 100 at a time through your full history."
+        }
       ]
     },
     {
@@ -195,20 +489,62 @@
       "date": "2026-06-10",
       "title": "Location Accuracy, Faster Loading & Linux Support",
       "changes": [
-        { "type": "fix", "description": "Fixed drives failing to load in 1.2.0 (\"Identifier 'isEventFolderPath' has already been declared\")." },
-        { "type": "feature", "description": "Linux support — releases now include an AppImage (with the same auto-update as Windows) and a .deb package." },
-        { "type": "feature", "description": "Redesigned map layers — Light and Dark are now both Google Maps (Dark in Google's night-mode colors), decluttered to show only city and neighborhood labels alongside your drive lines. Satellite gains the same labels. A toggle in Settings → Map UI hides labels entirely, and Light is the new default." },
-        { "type": "feature", "description": "New Support tab in Settings — save recent app errors and events as a text file to attach to bug reports." },
-        { "type": "improvement", "description": "Drive data loads dramatically faster — large files that took a minute now open in seconds." },
-        { "type": "improvement", "description": "Drive locations are more accurate — your car's own reported address is used when available, and the GPS-based lookup is much more precise for everything else. Drives in unmapped areas show the nearest city instead of raw coordinates. Addresses may quietly update once after installing." },
-        { "type": "fix", "description": "Connecting Teslascope now works with the API key from Account → Security — it was previously rejected with \"Unauthorized (HTTP 401)\". The \"Get an API token\" link also opens the correct page now." },
-        { "type": "fix", "description": "The replay arrow now reliably faces the direction of travel — no more random swings while stopped in parking lots or stale headings at low speed." },
-        { "type": "improvement", "description": "Scrubbing the replay timeline always points the arrow the way the car was facing at that moment." },
-        { "type": "improvement", "description": "The selected drive now draws on top of the other drive lines on the map, instead of disappearing under them where routes cross." },
-        { "type": "improvement", "description": "The Import Drives dialog is much more responsive — switching services shows your vehicles instantly, changing dates no longer fires a query per click, and date fields open a calendar picker." },
-        { "type": "improvement", "description": "\"Check for Update\" now clearly shows what it's doing — a visible checking state, then a clear answer: update found, you're up to date, or what went wrong. When an update is available, the download button in the corner pulses yellow." },
-        { "type": "improvement", "description": "Processing large clip libraries is faster, and an interrupted run can no longer corrupt your drive data." },
-        { "type": "fix", "description": "Saving tags and importing drives no longer fails on very large drive-data files." }
+        {
+          "type": "fix",
+          "description": "Fixed drives failing to load in 1.2.0 (\"Identifier 'isEventFolderPath' has already been declared\")."
+        },
+        {
+          "type": "feature",
+          "description": "Linux support — releases now include an AppImage (with the same auto-update as Windows) and a .deb package."
+        },
+        {
+          "type": "feature",
+          "description": "Redesigned map layers — Light and Dark are now both Google Maps (Dark in Google's night-mode colors), decluttered to show only city and neighborhood labels alongside your drive lines. Satellite gains the same labels. A toggle in Settings → Map UI hides labels entirely, and Light is the new default."
+        },
+        {
+          "type": "feature",
+          "description": "New Support tab in Settings — save recent app errors and events as a text file to attach to bug reports."
+        },
+        {
+          "type": "improvement",
+          "description": "Drive data loads dramatically faster — large files that took a minute now open in seconds."
+        },
+        {
+          "type": "improvement",
+          "description": "Drive locations are more accurate — your car's own reported address is used when available, and the GPS-based lookup is much more precise for everything else. Drives in unmapped areas show the nearest city instead of raw coordinates. Addresses may quietly update once after installing."
+        },
+        {
+          "type": "fix",
+          "description": "Connecting Teslascope now works with the API key from Account → Security — it was previously rejected with \"Unauthorized (HTTP 401)\". The \"Get an API token\" link also opens the correct page now."
+        },
+        {
+          "type": "fix",
+          "description": "The replay arrow now reliably faces the direction of travel — no more random swings while stopped in parking lots or stale headings at low speed."
+        },
+        {
+          "type": "improvement",
+          "description": "Scrubbing the replay timeline always points the arrow the way the car was facing at that moment."
+        },
+        {
+          "type": "improvement",
+          "description": "The selected drive now draws on top of the other drive lines on the map, instead of disappearing under them where routes cross."
+        },
+        {
+          "type": "improvement",
+          "description": "The Import Drives dialog is much more responsive — switching services shows your vehicles instantly, changing dates no longer fires a query per click, and date fields open a calendar picker."
+        },
+        {
+          "type": "improvement",
+          "description": "\"Check for Update\" now clearly shows what it's doing — a visible checking state, then a clear answer: update found, you're up to date, or what went wrong. When an update is available, the download button in the corner pulses yellow."
+        },
+        {
+          "type": "improvement",
+          "description": "Processing large clip libraries is faster, and an interrupted run can no longer corrupt your drive data."
+        },
+        {
+          "type": "fix",
+          "description": "Saving tags and importing drives no longer fails on very large drive-data files."
+        }
       ]
     },
     {
@@ -216,12 +552,26 @@
       "date": "2026-06-07",
       "title": "Settings Redesign & Multi-Service Drive Import",
       "changes": [
-        { "type": "feature", "description": "Teslascope import — connect your Teslascope account and import your drives directly, alongside Tessie. NOTE: Untested. Feedback requested." },
-        { "type": "improvement", "description": "Improved drive tag handling." },
-        { "type": "improvement", "description": "Unified UI design with the rest of the Sentry Six product line." },
-		{ "type": "improvement", "description": "More accurate mileage — drive distances are now computed on the WGS-84 ellipsoid instead of a spherical Earth model. Displayed distances may shift by up to ~0.3%; the new figures are the more accurate ones." },
-        { "type": "fix", "description": "Deleting a drive now removes it from the map immediately, instead of lingering until you switch to another drive." }
-        
+        {
+          "type": "feature",
+          "description": "Teslascope import — connect your Teslascope account and import your drives directly, alongside Tessie. NOTE: Untested. Feedback requested."
+        },
+        {
+          "type": "improvement",
+          "description": "Improved drive tag handling."
+        },
+        {
+          "type": "improvement",
+          "description": "Unified UI design with the rest of the Sentry Six product line."
+        },
+        {
+          "type": "improvement",
+          "description": "More accurate mileage — drive distances are now computed on the WGS-84 ellipsoid instead of a spherical Earth model. Displayed distances may shift by up to ~0.3%; the new figures are the more accurate ones."
+        },
+        {
+          "type": "fix",
+          "description": "Deleting a drive now removes it from the map immediately, instead of lingering until you switch to another drive."
+        }
       ]
     },
     {
@@ -229,8 +579,14 @@
       "date": "2026-05-18",
       "title": "Large File Support",
       "changes": [
-        { "type": "improvement", "description": "Sentry Drive can now open drive-data.json files in the hundreds-of-MB to ~1GB range without crashing. The file is read incrementally with a streaming JSON parser instead of being loaded into memory all at once, and the main process is given more heap headroom — files that previously triggered an out-of-memory crash on load should now open successfully." },
-        { "type": "improvement", "description": "The loading screen now shows a progress bar with MB read / total so large files don't look like the app is frozen." }
+        {
+          "type": "improvement",
+          "description": "Sentry Drive can now open drive-data.json files in the hundreds-of-MB to ~1GB range without crashing. The file is read incrementally with a streaming JSON parser instead of being loaded into memory all at once, and the main process is given more heap headroom — files that previously triggered an out-of-memory crash on load should now open successfully."
+        },
+        {
+          "type": "improvement",
+          "description": "The loading screen now shows a progress bar with MB read / total so large files don't look like the app is frozen."
+        }
       ]
     },
     {
@@ -238,7 +594,10 @@
       "date": "2026-05-18",
       "title": "Memory Leak Fix",
       "changes": [
-        { "type": "fix", "description": "Fixed a memory leak that caused the app to crash after viewing many drives in a single session — full drive GPS data is now released when switching to another drive or returning to the overview, keeping memory usage stable over long sessions." }
+        {
+          "type": "fix",
+          "description": "Fixed a memory leak that caused the app to crash after viewing many drives in a single session — full drive GPS data is now released when switching to another drive or returning to the overview, keeping memory usage stable over long sessions."
+        }
       ]
     },
     {
@@ -246,9 +605,18 @@
       "date": "2026-05-18",
       "title": "GPS Accuracy & UI Fixes",
       "changes": [
-        { "type": "improvement", "description": "GPS distance calculation now removes null-island points and applies group-level outlier filtering (matching Sentry USB Rusty) before computing drive distance — mileage figures are more accurate on drives with GPS noise or a slow satellite lock." },
-        { "type": "fix", "description": "The \"What's New\" modal no longer appears over the loading spinner on startup — it now waits until drive data has finished loading." },
-        { "type": "fix", "description": "Tessie-imported drive lines now appear grey like native drives when viewing a specific drive, instead of remaining purple." }
+        {
+          "type": "improvement",
+          "description": "GPS distance calculation now removes null-island points and applies group-level outlier filtering (matching Sentry USB Rusty) before computing drive distance — mileage figures are more accurate on drives with GPS noise or a slow satellite lock."
+        },
+        {
+          "type": "fix",
+          "description": "The \"What's New\" modal no longer appears over the loading spinner on startup — it now waits until drive data has finished loading."
+        },
+        {
+          "type": "fix",
+          "description": "Tessie-imported drive lines now appear grey like native drives when viewing a specific drive, instead of remaining purple."
+        }
       ]
     },
     {
@@ -256,16 +624,46 @@
       "date": "2026-05-17",
       "title": "Custom Markers, Tessie Import & Analytics Polish",
       "changes": [
-        { "type": "feature", "description": "Delete drives — remove any drive from your drive list directly from the app." },
-        { "type": "feature", "description": "Revert to stable — if you're on a beta build, you can roll back to the last stable release from Settings." },
-        { "type": "feature", "description": "Tessie API import — enter your Tessie access token, select your vehicle, set a date range, preview the import count, and confirm to pull drives directly from the Tessie API." },
-        { "type": "feature", "description": "Tessie CSV import — alternatively, import drives from a Tessie CSV export (drives + driving states files)." },
-        { "type": "feature", "description": "Choose your replay marker in Settings — pick between the classic Arrow or a Model 3 top-down view." },
-        { "type": "feature", "description": "Added ability to change map replay marker from arrow to car (only legacy Model 3 at the moment)." },
-        { "type": "improvement", "description": "FSD analytics donut chart center now shows a rating label (Great / Good / Okay / Bad) based on FSD usage, with the percentage shown below it." },
-        { "type": "improvement", "description": "Time with FSD is now shown in the drive analytics legend." },
-        { "type": "improvement", "description": "Aggregate analytics now include average disengagements and average accelerator overrides per drive." },
-        { "type": "fix", "description": "Scrubbing the timeline now snaps the direction arrow immediately instead of animating from its previous position." }
+        {
+          "type": "feature",
+          "description": "Delete drives — remove any drive from your drive list directly from the app."
+        },
+        {
+          "type": "feature",
+          "description": "Revert to stable — if you're on a beta build, you can roll back to the last stable release from Settings."
+        },
+        {
+          "type": "feature",
+          "description": "Tessie API import — enter your Tessie access token, select your vehicle, set a date range, preview the import count, and confirm to pull drives directly from the Tessie API."
+        },
+        {
+          "type": "feature",
+          "description": "Tessie CSV import — alternatively, import drives from a Tessie CSV export (drives + driving states files)."
+        },
+        {
+          "type": "feature",
+          "description": "Choose your replay marker in Settings — pick between the classic Arrow or a Model 3 top-down view."
+        },
+        {
+          "type": "feature",
+          "description": "Added ability to change map replay marker from arrow to car (only legacy Model 3 at the moment)."
+        },
+        {
+          "type": "improvement",
+          "description": "FSD analytics donut chart center now shows a rating label (Great / Good / Okay / Bad) based on FSD usage, with the percentage shown below it."
+        },
+        {
+          "type": "improvement",
+          "description": "Time with FSD is now shown in the drive analytics legend."
+        },
+        {
+          "type": "improvement",
+          "description": "Aggregate analytics now include average disengagements and average accelerator overrides per drive."
+        },
+        {
+          "type": "fix",
+          "description": "Scrubbing the timeline now snaps the direction arrow immediately instead of animating from its previous position."
+        }
       ]
     },
     {
@@ -273,13 +671,34 @@
       "date": "2026-04-25",
       "title": "Tessie Import & Analytics Polish",
       "changes": [
-        { "type": "feature", "description": "Import drives directly from the Tessie API — enter your access token, select your vehicle, pick a date range, preview how many drives will be imported, then confirm." },
-        { "type": "feature", "description": "Import drives from Tessie CSV exports (drives + driving states files) as an alternative to the API." },
-        { "type": "improvement", "description": "Tessie drives that overlap with real dashcam drives are automatically hidden to avoid duplicates." },
-        { "type": "improvement", "description": "FSD analytics donut chart center now shows a rating label (Great / Good / Okay / Bad) based on FSD usage, with the percentage shown below it." },
-        { "type": "improvement", "description": "Time with FSD is now shown in the drive analytics legend." },
-        { "type": "improvement", "description": "Aggregate analytics now show average disengagements and average accelerator overrides per drive." },
-        { "type": "fix", "description": "Scrubbing the timeline now snaps the direction arrow immediately instead of animating from its previous position." }
+        {
+          "type": "feature",
+          "description": "Import drives directly from the Tessie API — enter your access token, select your vehicle, pick a date range, preview how many drives will be imported, then confirm."
+        },
+        {
+          "type": "feature",
+          "description": "Import drives from Tessie CSV exports (drives + driving states files) as an alternative to the API."
+        },
+        {
+          "type": "improvement",
+          "description": "Tessie drives that overlap with real dashcam drives are automatically hidden to avoid duplicates."
+        },
+        {
+          "type": "improvement",
+          "description": "FSD analytics donut chart center now shows a rating label (Great / Good / Okay / Bad) based on FSD usage, with the percentage shown below it."
+        },
+        {
+          "type": "improvement",
+          "description": "Time with FSD is now shown in the drive analytics legend."
+        },
+        {
+          "type": "improvement",
+          "description": "Aggregate analytics now show average disengagements and average accelerator overrides per drive."
+        },
+        {
+          "type": "fix",
+          "description": "Scrubbing the timeline now snaps the direction arrow immediately instead of animating from its previous position."
+        }
       ]
     },
     {
@@ -287,16 +706,25 @@
       "date": "2026-04-25",
       "title": "Drive Removal & Revert to Stable",
       "changes": [
-        { "type": "feature", "description": "You can now delete drives from your drive list." },
-        { "type": "feature", "description": "Added option to revert to the last stable build from Settings when on a beta version." }
+        {
+          "type": "feature",
+          "description": "You can now delete drives from your drive list."
+        },
+        {
+          "type": "feature",
+          "description": "Added option to revert to the last stable build from Settings when on a beta version."
+        }
       ]
     },
-	{
+    {
       "version": "1.1.1",
       "date": "2026-04-23",
       "title": "Sentry USB Drive Data Fix",
       "changes": [
-        { "type": "fix", "description": "Fixed an issue where Sentry Drive did not properly read the drive-data.json from Sentry USB." }
+        {
+          "type": "fix",
+          "description": "Fixed an issue where Sentry Drive did not properly read the drive-data.json from Sentry USB."
+        }
       ]
     },
     {
@@ -304,24 +732,78 @@
       "date": "2026-04-23",
       "title": "Drive Analytics, Map Layers & Unit Support",
       "changes": [
-        { "type": "feature", "description": "FSD Analytics panel — click the stats panel to see a more detailed view of Full Self-Driving, Autopilot, TACC, and Manual miles, plus total disengagements and accelerator overrides." },
-        { "type": "feature", "description": "Color-coded FSD Score in the stats panel — red for low, green for high, with a smooth gradient between." },
-        { "type": "feature", "description": "Drive Timeline for browsing drives chronologically." },
-        { "type": "feature", "description": "Google Maps and Satellite base layers — switch from the layer control in the top-right of the map." },
-        { "type": "feature", "description": "Imperial / Metric unit toggle in Settings." },
-        { "type": "feature", "description": "Added toggle for showing FSD markers (disengagements and accelerator overrides) on drives." },
-        { "type": "improvement", "description": "Added stats for specific drives." },
-        { "type": "improvement", "description": "Added drive timeline with scrubbing." },
-        { "type": "improvement", "description": "Confirmation dialogs added to Check Drives and Revert Drives to avoid accidental triggers." },
-		{ "type": "fix", "description": "Processing runs on the app's bundled Node runtime — no separate Node.js install required." },
-        { "type": "fix", "description": "Process New Drives no longer fails silently on installed builds." },
-        { "type": "fix", "description": "Direction arrow no longer spins full circles when switching between drive and reverse." },
-        { "type": "fix", "description": "Clicking the map while viewing a specific drive no longer returns you to the overview." },
-        { "type": "fix", "description": "Dismissing the Changelog modal no longer closes the Settings modal behind it." },
-        { "type": "fix", "description": "Switching drives during playback no longer leaves the previous replay running, which could cause the new drive to continue playing through a pause." },
-        { "type": "fix", "description": "FSD, Autopilot, and Manual percentages are now rounded to whole numbers." },
-        { "type": "fix", "description": "Selecting a drive from the list no longer scrolls it behind the sticky date header." },
-        { "type": "fix", "description": "Tag edits inside the stats panel no longer collapse the FSD Analytics view." }
+        {
+          "type": "feature",
+          "description": "FSD Analytics panel — click the stats panel to see a more detailed view of Full Self-Driving, Autopilot, TACC, and Manual miles, plus total disengagements and accelerator overrides."
+        },
+        {
+          "type": "feature",
+          "description": "Color-coded FSD Score in the stats panel — red for low, green for high, with a smooth gradient between."
+        },
+        {
+          "type": "feature",
+          "description": "Drive Timeline for browsing drives chronologically."
+        },
+        {
+          "type": "feature",
+          "description": "Google Maps and Satellite base layers — switch from the layer control in the top-right of the map."
+        },
+        {
+          "type": "feature",
+          "description": "Imperial / Metric unit toggle in Settings."
+        },
+        {
+          "type": "feature",
+          "description": "Added toggle for showing FSD markers (disengagements and accelerator overrides) on drives."
+        },
+        {
+          "type": "improvement",
+          "description": "Added stats for specific drives."
+        },
+        {
+          "type": "improvement",
+          "description": "Added drive timeline with scrubbing."
+        },
+        {
+          "type": "improvement",
+          "description": "Confirmation dialogs added to Check Drives and Revert Drives to avoid accidental triggers."
+        },
+        {
+          "type": "fix",
+          "description": "Processing runs on the app's bundled Node runtime — no separate Node.js install required."
+        },
+        {
+          "type": "fix",
+          "description": "Process New Drives no longer fails silently on installed builds."
+        },
+        {
+          "type": "fix",
+          "description": "Direction arrow no longer spins full circles when switching between drive and reverse."
+        },
+        {
+          "type": "fix",
+          "description": "Clicking the map while viewing a specific drive no longer returns you to the overview."
+        },
+        {
+          "type": "fix",
+          "description": "Dismissing the Changelog modal no longer closes the Settings modal behind it."
+        },
+        {
+          "type": "fix",
+          "description": "Switching drives during playback no longer leaves the previous replay running, which could cause the new drive to continue playing through a pause."
+        },
+        {
+          "type": "fix",
+          "description": "FSD, Autopilot, and Manual percentages are now rounded to whole numbers."
+        },
+        {
+          "type": "fix",
+          "description": "Selecting a drive from the list no longer scrolls it behind the sticky date header."
+        },
+        {
+          "type": "fix",
+          "description": "Tag edits inside the stats panel no longer collapse the FSD Analytics view."
+        }
       ]
     },
     {
@@ -329,10 +811,22 @@
       "date": "2026-04-22",
       "title": "Update Modal Preview and Confirmation Modals",
       "changes": [
-        { "type": "improvement", "description": "Update Available modal now previews the incoming version's changelog entry." },
-        { "type": "improvement", "description": "ALPHA status appended to Check Drives confirmation." },
-        { "type": "improvement", "description": "Replay play/pause button restyled as a rounded square to match the rest of the UI." },
-        { "type": "fix", "description": "Switching drives during playback no longer leaves the previous replay interval running, which could cause the new drive to continue playing through a pause." }
+        {
+          "type": "improvement",
+          "description": "Update Available modal now previews the incoming version's changelog entry."
+        },
+        {
+          "type": "improvement",
+          "description": "ALPHA status appended to Check Drives confirmation."
+        },
+        {
+          "type": "improvement",
+          "description": "Replay play/pause button restyled as a rounded square to match the rest of the UI."
+        },
+        {
+          "type": "fix",
+          "description": "Switching drives during playback no longer leaves the previous replay interval running, which could cause the new drive to continue playing through a pause."
+        }
       ]
     },
     {
@@ -340,19 +834,58 @@
       "date": "2026-04-22",
       "title": "Drive Stats Panel & FSD Analytics",
       "changes": [
-        { "type": "feature", "description": "Color-coded FSD Score in the stats panel — red for low, green for high, with a smooth gradient between." },
-        { "type": "feature", "description": "Click the stats panel to expand an FSD Analytics view — donut chart breaking down Full Self-Driving, Autopilot, TACC, and Manual miles, plus total disengagements and accelerator overrides." },
-        { "type": "improvement", "description": "Selecting a specific drive swaps the aggregate stats panel for that drive's own stats and breakdown; back to overview restores the aggregate view." },
-        { "type": "improvement", "description": "Drive date/time header and tags moved into the stats panel — sidebar is cleaner, editing stays in place as you switch drives." },
-        { "type": "improvement", "description": "Timeline is now visually merged with the bottom edge of the stats panel as a single dock at the bottom of the map." },
-        { "type": "improvement", "description": "Current-time label floats directly above the timeline thumb and tracks with it as you scrub or play." },
-        { "type": "improvement", "description": "Stats panel cleanup — removed the Clips count, renamed “Miles” to “Miles Driven”." },
-        { "type": "improvement", "description": "Confirmation dialog icons are now filled rounded squares instead of outlined circles, matching the rest of the UI." },
-        { "type": "improvement", "description": "Settings → Map → new toggle for showing FSD markers (disengagements and accelerator overrides) on drives." },
-        { "type": "improvement", "description": "Renamed “Accel Overrides” to “Accelerator Overrides” in the stats panel." },
-        { "type": "fix", "description": "FSD, Autopilot, and Manual percentages are rounded to whole numbers." },
-        { "type": "fix", "description": "Selecting a drive from the list no longer scrolls it behind the sticky date header." },
-        { "type": "fix", "description": "Tag edits inside the stats panel no longer toggle the expanded view." }
+        {
+          "type": "feature",
+          "description": "Color-coded FSD Score in the stats panel — red for low, green for high, with a smooth gradient between."
+        },
+        {
+          "type": "feature",
+          "description": "Click the stats panel to expand an FSD Analytics view — donut chart breaking down Full Self-Driving, Autopilot, TACC, and Manual miles, plus total disengagements and accelerator overrides."
+        },
+        {
+          "type": "improvement",
+          "description": "Selecting a specific drive swaps the aggregate stats panel for that drive's own stats and breakdown; back to overview restores the aggregate view."
+        },
+        {
+          "type": "improvement",
+          "description": "Drive date/time header and tags moved into the stats panel — sidebar is cleaner, editing stays in place as you switch drives."
+        },
+        {
+          "type": "improvement",
+          "description": "Timeline is now visually merged with the bottom edge of the stats panel as a single dock at the bottom of the map."
+        },
+        {
+          "type": "improvement",
+          "description": "Current-time label floats directly above the timeline thumb and tracks with it as you scrub or play."
+        },
+        {
+          "type": "improvement",
+          "description": "Stats panel cleanup — removed the Clips count, renamed “Miles” to “Miles Driven”."
+        },
+        {
+          "type": "improvement",
+          "description": "Confirmation dialog icons are now filled rounded squares instead of outlined circles, matching the rest of the UI."
+        },
+        {
+          "type": "improvement",
+          "description": "Settings → Map → new toggle for showing FSD markers (disengagements and accelerator overrides) on drives."
+        },
+        {
+          "type": "improvement",
+          "description": "Renamed “Accel Overrides” to “Accelerator Overrides” in the stats panel."
+        },
+        {
+          "type": "fix",
+          "description": "FSD, Autopilot, and Manual percentages are rounded to whole numbers."
+        },
+        {
+          "type": "fix",
+          "description": "Selecting a drive from the list no longer scrolls it behind the sticky date header."
+        },
+        {
+          "type": "fix",
+          "description": "Tag edits inside the stats panel no longer toggle the expanded view."
+        }
       ]
     },
     {
@@ -360,17 +893,50 @@
       "date": "2026-04-22",
       "title": "Map Layers, Units, and Polish",
       "changes": [
-        { "type": "feature", "description": "Added Google Maps and Satellite base layers — switch from the new layer control in the top-right of the map." },
-        { "type": "feature", "description": "Imperial / Metric unit toggle in Settings." },
-        { "type": "improvement", "description": "Window size and maximized state are remembered across launches." },
-        { "type": "improvement", "description": "Relocated drive timeline to above the overall drive stats." },
-        { "type": "improvement", "description": "Added confirmation checks to Check Drives and Revert Drives buttons to avoid accidental triggers." },
-        { "type": "improvement", "description": "Settings restyled — toggle pills, compact Imperial/Metric switch." },
-        { "type": "improvement", "description": "Overview drive lines are now smoothed out." },
-        { "type": "fix", "description": "Fixed bug related to Play/Pause button not working." },
-        { "type": "fix", "description": "Arrow no longer spins full circles at certain points or when switching between drive and reverse." },
-        { "type": "fix", "description": "Clicking on the map while viewing a specific drive no longer kicks you back to the overview." },
-        { "type": "fix", "description": "Dismissing the Change Log modal no longer also closes the Settings modal behind it." }
+        {
+          "type": "feature",
+          "description": "Added Google Maps and Satellite base layers — switch from the new layer control in the top-right of the map."
+        },
+        {
+          "type": "feature",
+          "description": "Imperial / Metric unit toggle in Settings."
+        },
+        {
+          "type": "improvement",
+          "description": "Window size and maximized state are remembered across launches."
+        },
+        {
+          "type": "improvement",
+          "description": "Relocated drive timeline to above the overall drive stats."
+        },
+        {
+          "type": "improvement",
+          "description": "Added confirmation checks to Check Drives and Revert Drives buttons to avoid accidental triggers."
+        },
+        {
+          "type": "improvement",
+          "description": "Settings restyled — toggle pills, compact Imperial/Metric switch."
+        },
+        {
+          "type": "improvement",
+          "description": "Overview drive lines are now smoothed out."
+        },
+        {
+          "type": "fix",
+          "description": "Fixed bug related to Play/Pause button not working."
+        },
+        {
+          "type": "fix",
+          "description": "Arrow no longer spins full circles at certain points or when switching between drive and reverse."
+        },
+        {
+          "type": "fix",
+          "description": "Clicking on the map while viewing a specific drive no longer kicks you back to the overview."
+        },
+        {
+          "type": "fix",
+          "description": "Dismissing the Change Log modal no longer also closes the Settings modal behind it."
+        }
       ]
     },
     {
@@ -378,8 +944,14 @@
       "date": "2026-04-22",
       "title": "Processing Fix",
       "changes": [
-        { "type": "fix", "description": "Process New Drives no longer fails silently on installed builds." },
-        { "type": "improvement", "description": "Processing runs on the app’s bundled Node runtime — no separate Node.js install required." }
+        {
+          "type": "fix",
+          "description": "Process New Drives no longer fails silently on installed builds."
+        },
+        {
+          "type": "improvement",
+          "description": "Processing runs on the app’s bundled Node runtime — no separate Node.js install required."
+        }
       ]
     },
     {
@@ -387,9 +959,18 @@
       "date": "2026-04-22",
       "title": "Drive Timeline & Beta Channel",
       "changes": [
-        { "type": "feature", "description": "Drive Timeline view for browsing drives chronologically." },
-        { "type": "feature", "description": "Beta update channel — enroll in Settings to receive pre-release builds." },
-        { "type": "improvement", "description": "Processing pipeline split into separate, reusable functions." }
+        {
+          "type": "feature",
+          "description": "Drive Timeline view for browsing drives chronologically."
+        },
+        {
+          "type": "feature",
+          "description": "Beta update channel — enroll in Settings to receive pre-release builds."
+        },
+        {
+          "type": "improvement",
+          "description": "Processing pipeline split into separate, reusable functions."
+        }
       ]
     },
     {
@@ -397,10 +978,22 @@
       "date": "2026-04-17",
       "title": "Initial Release",
       "changes": [
-        { "type": "feature", "description": "Process Tesla dashcam clips into drive-data.json." },
-        { "type": "feature", "description": "View drives on an interactive map with route overlays." },
-        { "type": "feature", "description": "GPS repair for gaps in dashcam logs using OSRM routing." },
-        { "type": "feature", "description": "Drive tagging for organization and filtering." }
+        {
+          "type": "feature",
+          "description": "Process Tesla dashcam clips into drive-data.json."
+        },
+        {
+          "type": "feature",
+          "description": "View drives on an interactive map with route overlays."
+        },
+        {
+          "type": "feature",
+          "description": "GPS repair for gaps in dashcam logs using OSRM routing."
+        },
+        {
+          "type": "feature",
+          "description": "Drive tagging for organization and filtering."
+        }
       ]
     }
   ]

--- a/changelog.json
+++ b/changelog.json
@@ -1,6 +1,16 @@
 {
   "versions": [
     {
+      "version": "1.4.1",
+      "date": "2026-07-01",
+      "title": "Removal Feedback & Marker Centering",
+      "changes": [
+        { "type": "improvement", "description": "Removing a drive, removing imported drives, and reverting to a backup no longer look like a freeze — the loading spinner now stays up while the drive data file is rewritten and the list refreshes." },
+        { "type": "fix", "description": "The letters on the FSD event markers (A and D) now sit truly centered in their circles — their position is measured from the font's actual glyph bounds on both axes instead of approximated." },
+        { "type": "improvement", "description": "Location labels on drive cards are more accurate: lookups now only match real addresses and businesses, and a business name or house number is used only when it is verifiably at the drive's coordinates — otherwise the label falls back to the street instead of naming the wrong building. Existing labels refresh automatically over time." }
+      ]
+    },
+    {
       "version": "1.4.0",
       "date": "2026-07-01",
       "title": "Green Theme, Vehicle Markers & Customization",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sentry-drive",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sentry-drive",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "dependencies": {
         "electron-updater": "^6.8.9",
         "stream-chain": "^4.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sentry-drive",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sentry-drive",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "electron-updater": "^6.8.3",
         "stream-chain": "^3.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-drive",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "description": "Standalone Tesla dashcam drives processor - replicates Sentry USB drives processing",
   "main": "src/main/electron-main.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-drive",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "type": "module",
   "description": "Standalone Tesla dashcam drives processor - replicates Sentry USB drives processing",
   "main": "src/main/electron-main.cjs",

--- a/src/main/drive-data-reader.cjs
+++ b/src/main/drive-data-reader.cjs
@@ -27,7 +27,12 @@ const { chain } = require('stream-chain');
 // destructure the factory/class. The root default is parserStream (a Duplex
 // factory), not the chain-stage parser — don't use it here.
 const { parser } = require('stream-json/parser.js');
-const { Assembler } = require('stream-json/assembler.js');
+// The Assembler export shape changed across stream-json releases: newer
+// builds export the class as the module itself (with an `assembler` factory
+// attached), older ones as a named export. Accept both so a dependency bump
+// can't silently break the streaming fallback again.
+const AssemblerModule = require('stream-json/assembler.js');
+const Assembler = AssemblerModule.Assembler ?? AssemblerModule;
 
 // Safely below V8's ~512 MiB max-string-length, with margin for multi-byte
 // UTF-8 (byte size >= char count, so a 480 MB file is always parseable).

--- a/src/main/electron-main.cjs
+++ b/src/main/electron-main.cjs
@@ -294,6 +294,34 @@ ipcMain.handle('remove-drive', (_e, { filePath, driveStartTime }) => withDriveDa
   }
 }));
 
+// Bulk removal for the drive list's multi-select: same semantics as
+// remove-drive, but one read → one filter pass → one atomic write for the
+// whole batch (a rewrite per drive would grind on large libraries).
+ipcMain.handle('remove-drives', (_e, { filePath, driveStartTimes }) => withDriveDataLock(async () => {
+  try {
+    const wanted = new Set(driveStartTimes ?? []);
+    if (wanted.size === 0) return { success: false, error: 'No drives given' };
+    const data = await readDriveData(filePath, { wantProcessedFiles: true });
+    const { groupIntoDrives } = await import('../processing/grouper.js');
+    const { drives } = groupIntoDrives(data.routes ?? []);
+    const targets = drives.filter((d) => wanted.has(d.startTime));
+    if (targets.length === 0) return { success: false, error: 'Drives not found' };
+
+    const removeSet = new Set(targets.flatMap((t) => t.routeFiles.map((f) => f.replace(/\\/g, '/'))));
+    data.routes = (data.routes ?? []).filter((r) => !removeSet.has(r.file.replace(/\\/g, '/')));
+    data.processedFiles = (data.processedFiles ?? []).filter((f) => !removeSet.has(f.replace(/\\/g, '/')));
+    if (data.driveTags) for (const t of targets) delete data.driveTags[t.startTime];
+
+    data.routes = await routesToWireFormat(data.routes);
+    await writeDriveDataJSON(filePath, data);
+    logger.info('main', `removed ${targets.length} drive(s) (${removeSet.size} clip(s)) via multi-select`);
+    return { success: true, removed: targets.length };
+  } catch (err) {
+    logger.error('main', 'remove drives failed:', err?.message ?? err);
+    return { success: false, error: err.message };
+  }
+}));
+
 ipcMain.handle('revert-to-stable', () => {
   autoUpdater.allowPrerelease = false;
   autoUpdater.allowDowngrade = true;
@@ -423,6 +451,10 @@ ipcMain.handle('load-and-group-drives', async (_e, filePath) => {
     // context bridge (the main cause of the V8 heap OOM on large files).
     driveDetailCache = new Map();
     for (const d of drives) {
+      // Bridge routes are the synthetic `-front-bridge.mp4` entries Check
+      // Drives writes into GPS gaps — flag drives containing one so the UI
+      // can show which drives were bridged.
+      d.bridged = (d.routeFiles ?? []).some((f) => f.includes('-front-bridge.mp4'));
       driveDetailCache.set(d.id, {
         points: d.points,
         fsdStates: d.fsdStates,

--- a/src/main/electron-preload.cjs
+++ b/src/main/electron-preload.cjs
@@ -37,6 +37,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   setAllowPrerelease: (allow) => ipcRenderer.invoke('set-allow-prerelease', allow),
   revertToStable: () => ipcRenderer.invoke('revert-to-stable'),
   removeDrive: (args) => ipcRenderer.invoke('remove-drive', args),
+  removeDrives: (args) => ipcRenderer.invoke('remove-drives', args),
   checkForUpdate: () => ipcRenderer.invoke('check-for-update'),
   downloadUpdate: () => ipcRenderer.invoke('download-update'),
   installUpdate: () => ipcRenderer.invoke('install-update'),

--- a/src/processing/geocode.cjs
+++ b/src/processing/geocode.cjs
@@ -12,14 +12,30 @@
 // the old 4-decimal key (~11 m) was wide enough to merge adjacent houses.
 // Bumping the precision orphans old 4-decimal cache entries (harmless; they
 // just re-resolve once at the new precision).
+//
+// Accuracy: a reverse lookup snaps to the NEAREST mapped feature, not to
+// "the address here". Lookups are therefore restricted to real addresses and
+// POIs (layer=address,poi), and the snapped feature's name/house number is
+// only used when the feature verifiably contains or nearly touches the
+// queried point (SNAP_TRUST_M); otherwise the label degrades gracefully to
+// the street / neighbourhood instead of naming the wrong building.
 
 const https = require('https');
 const fs = require('fs');
+const { geodesicM } = require('../shared/drive-calc.cjs');
 
 const HOST = 'nominatim.openstreetmap.org';
 const RATE_MS = 1100;          // ≤ 1 req/s per Nominatim policy (+ margin)
 const KEY_DECIMALS = 5;        // ~1.1 m grouping — house-level distinct
 const UA = 'Sentry-Drive/1.0 (https://github.com/JeffFromTheIRS/Sentry-Drive)';
+// Reverse geocoding snaps to the NEAREST mapped feature, which is not always
+// where the car is — only trust a feature's name/house number when it's
+// within this distance of the queried coordinates.
+const SNAP_TRUST_M = 75;
+// v2: snap-verified labels via layer=address,poi (v1 cached whatever object
+// Nominatim happened to snap to). Old entries are dropped on load and
+// re-resolve lazily through the throttle as cards render.
+const CACHE_VERSION = 2;
 
 let cache = null;              // { "lat,lng": label|null }
 let cacheFile = null;
@@ -29,8 +45,10 @@ const inflight = new Map();    // key -> Promise<label|null>
 
 function init(filePath) {
   cacheFile = filePath;
-  try { cache = JSON.parse(fs.readFileSync(filePath, 'utf8')) || {}; }
-  catch { cache = {}; }
+  try {
+    const raw = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    cache = raw && raw.__v === CACHE_VERSION && raw.entries ? raw.entries : {};
+  } catch { cache = {}; }
 }
 
 function keyFor(lat, lng) {
@@ -41,18 +59,48 @@ function scheduleSave() {
   if (saveTimer || !cacheFile) return;
   saveTimer = setTimeout(() => {
     saveTimer = null;
-    try { fs.writeFileSync(cacheFile, JSON.stringify(cache)); } catch {}
+    try { fs.writeFileSync(cacheFile, JSON.stringify({ __v: CACHE_VERSION, entries: cache })); } catch {}
   }, 2000);
+}
+
+// Distance from the queried coordinates to the matched feature's centroid.
+function resultDistanceM(j, lat, lng) {
+  const rlat = parseFloat(j.lat);
+  const rlng = parseFloat(j.lon);
+  if (!isFinite(rlat) || !isFinite(rlng)) return Infinity;
+  return geodesicM(lat, lng, rlat, rlng);
+}
+
+// Is the queried point inside the feature's bounding box, padded by padM?
+// Big features (a store + its lot) legitimately have a far-away centroid, so
+// name acceptance tests the box, not the centroid.
+function withinPaddedBBox(j, lat, lng, padM) {
+  const bb = j.boundingbox;
+  if (!Array.isArray(bb) || bb.length !== 4) return false;
+  const [minLat, maxLat, minLng, maxLng] = bb.map(Number);
+  if (![minLat, maxLat, minLng, maxLng].every(isFinite)) return false;
+  const latPad = padM / 111320;
+  const lngPad = padM / (111320 * Math.max(0.2, Math.cos((lat * Math.PI) / 180)));
+  return lat >= minLat - latPad && lat <= maxLat + latPad
+      && lng >= minLng - lngPad && lng <= maxLng + lngPad;
 }
 
 // Pick the most "pin-like" short label from a Nominatim reverse result:
 // POI/business name → "1234 Street" → street → neighbourhood/city.
-function shortLabel(j) {
+// The name and house number are only trusted when the matched feature is
+// verifiably AT the queried point — reverse geocoding snaps to the nearest
+// object, which can be the business across the street or a neighbour's
+// address point; in that case fall through to the street instead.
+function shortLabel(j, lat, lng) {
   if (!j) return null;
   const a = j.address || {};
-  if (j.name && j.name.trim()) return j.name.trim();              // POI/business name
+  if (j.name && j.name.trim() && withinPaddedBBox(j, lat, lng, SNAP_TRUST_M)) {
+    return j.name.trim();                                         // POI/business name
+  }
   const road = a.road || a.pedestrian || a.footway || a.path || a.cycleway;
-  if (road && a.house_number) return `${a.house_number} ${road}`; // "6730 Aviation Dr"
+  if (road && a.house_number && resultDistanceM(j, lat, lng) <= SNAP_TRUST_M) {
+    return `${a.house_number} ${road}`;                           // "6730 Aviation Dr"
+  }
   if (road) return road;
   const place = a.neighbourhood || a.suburb || a.hamlet || a.village
     || a.town || a.city || a.municipality || a.county;
@@ -74,9 +122,10 @@ function cityLabel(j) {
 
 // Resolves { ok: true, json } when Nominatim answered, or { ok: false } on
 // network error / timeout / non-2xx so the caller knows not to cache the miss.
-function requestNominatim(lat, lng, zoom) {
+function requestNominatim(lat, lng, zoom, layer) {
   return new Promise((resolve) => {
-    const path = `/reverse?format=jsonv2&lat=${lat}&lon=${lng}&zoom=${zoom}&addressdetails=1`;
+    const path = `/reverse?format=jsonv2&lat=${lat}&lon=${lng}&zoom=${zoom}&addressdetails=1`
+      + (layer ? `&layer=${layer}` : '');
     const req = https.get(
       { host: HOST, path, headers: { 'User-Agent': UA, Accept: 'application/json' }, timeout: 12000 },
       (res) => {
@@ -102,12 +151,12 @@ function requestNominatim(lat, lng, zoom) {
 // per-call delays computed against a shared timestamp would let the whole
 // burst fire simultaneously and trip Nominatim's rate ban.
 let queueTail = Promise.resolve();
-function fetchNominatim(lat, lng, zoom) {
+function fetchNominatim(lat, lng, zoom, layer) {
   const run = queueTail.then(async () => {
     const wait = RATE_MS - (Date.now() - lastFetchMs);
     if (wait > 0) await new Promise((r) => setTimeout(r, wait));
     lastFetchMs = Date.now();
-    return requestNominatim(lat, lng, zoom);
+    return requestNominatim(lat, lng, zoom, layer);
   });
   queueTail = run.catch(() => {});
   return run;
@@ -127,9 +176,11 @@ async function reverseGeocode(lat, lng) {
   if (inflight.has(key)) return inflight.get(key);
 
   const p = (async () => {
-    const street = await fetchNominatim(lat, lng, 18);
+    // layer=address,poi keeps the snap on real addresses and businesses —
+    // without it Nominatim happily matches railways, streams, power poles…
+    const street = await fetchNominatim(lat, lng, 18, 'address,poi');
     if (!street.ok) { inflight.delete(key); return null; }
-    let label = shortLabel(street.json);
+    let label = shortLabel(street.json, lat, lng);
     if (!label) {
       const city = await fetchNominatim(lat, lng, 10);
       if (!city.ok) { inflight.delete(key); return null; }

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -113,6 +113,13 @@
 
         <div id="drives-list"></div>
 
+        <!-- Floating action bar for multi-selected drives (Ctrl/Shift+click) -->
+        <div id="multi-select-bar" class="hidden">
+          <span id="multi-select-count">0 drives selected</span>
+          <button id="btn-multi-remove" class="btn-danger" type="button"><span class="material-icons">delete_sweep</span>Remove</button>
+          <button id="btn-multi-clear" type="button" title="Clear selection"><span class="material-icons">close</span></button>
+        </div>
+
       </div>
 
       <!-- ── Panel Footer (always visible) ──────────────────────────── -->
@@ -149,6 +156,7 @@
         </div>
         <div class="settings-tabs" role="tablist">
           <button class="settings-tab-btn active" data-stab="general" type="button" role="tab">General</button>
+          <button class="settings-tab-btn" data-stab="privacy" type="button" role="tab">Privacy</button>
           <button class="settings-tab-btn" data-stab="mapui" type="button" role="tab">Map UI</button>
           <button class="settings-tab-btn" data-stab="integrations" type="button" role="tab">Integrations</button>
           <button class="settings-tab-btn" data-stab="support" type="button" role="tab">Support</button>
@@ -198,6 +206,19 @@
               </div>
             </div>
           </div>
+          <div class="settings-pane" id="stab-privacy">
+            <div class="settings-section">
+              <div class="settings-section-header">
+                <span class="settings-section-icon halo-accent"><span class="material-icons">shield</span></span>
+                <span class="settings-section-title">Privacy Zones</span>
+              </div>
+              <div class="settings-section-body">
+                <div class="privacy-zones-hint">Draw a circle around Home, Work, or any custom spot, then cull the drives that start or end inside it. Zones are stored only on this device — never in your drive data file.</div>
+                <div id="privacy-zones-list"></div>
+                <button id="btn-add-zone" class="btn-add-zone" type="button"><span class="material-icons">add_location_alt</span>Add custom location</button>
+              </div>
+            </div>
+          </div>
           <div class="settings-pane" id="stab-mapui">
             <div class="settings-section">
               <div class="settings-section-header">
@@ -212,6 +233,10 @@
                 <label class="settings-checkbox-row" title="Disengagements and accelerator overrides">
                   <span class="settings-checkbox-label">Show FSD markers</span>
                   <input type="checkbox" id="chk-show-fsd-markers" class="settings-checkbox" />
+                </label>
+                <label class="settings-checkbox-row" title="Home, Work, and custom privacy zone pins">
+                  <span class="settings-checkbox-label">Show zone markers</span>
+                  <input type="checkbox" id="chk-show-zone-markers" class="settings-checkbox" />
                 </label>
                 <label class="settings-checkbox-row" title="City and neighborhood names on the map">
                   <span class="settings-checkbox-label">Show city labels</span>
@@ -405,6 +430,19 @@
       </div>
     </div>
 
+    <!-- ── Remove Selected Drives Confirm Modal (multi-select) ─────────── -->
+    <div id="remove-drives-overlay" class="hidden">
+      <div class="reprocess-modal">
+        <div class="reprocess-modal-icon halo-red"><span class="material-icons">delete_sweep</span></div>
+        <div class="reprocess-modal-title">Remove Selected Drives?</div>
+        <div id="remove-drives-modal-msg" class="reprocess-modal-msg"></div>
+        <div class="reprocess-modal-actions">
+          <button id="btn-remove-drives-confirm" class="btn-danger btn-update-full">Remove Drives</button>
+          <button id="btn-remove-drives-cancel" class="update-skip-btn">Cancel</button>
+        </div>
+      </div>
+    </div>
+
     <!-- ── Tessie Import Modal ─────────────────────────────────────── -->
     <div id="tessie-overlay" class="hidden">
       <div id="tessie-modal">
@@ -580,6 +618,13 @@
     <!-- ── Map Panel ────────────────────────────────────────────────── -->
     <div id="map-container">
       <div id="map"></div>
+      <div id="map-pick-hint" class="hidden">
+        <span id="map-pick-hint-text"></span>
+        <span id="map-pick-actions" class="hidden">
+          <button id="btn-zone-save" type="button">Save zone</button>
+          <button id="btn-zone-cancel" type="button">Cancel</button>
+        </span>
+      </div>
       <div id="loading-overlay" class="hidden">
         <div class="loading-content">
           <div class="loading-spinner"></div>
@@ -632,6 +677,10 @@
   </div>
 
   <!-- ── Car Color Picker Popup ────────────────────────────────────────── -->
+  <div id="zone-icon-popup" class="hidden">
+    <div class="zone-icon-grid"></div>
+  </div>
+
   <div id="car-color-popup" class="hidden">
     <div class="car-color-popup-header">
       <span class="car-color-popup-title">Car Color</span>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -234,7 +234,9 @@
                   <select id="sel-marker-type" class="settings-select">
                     <option value="arrow">Arrow</option>
                     <option value="model3">Model 3</option>
+                    <option value="highland">Highland</option>
                     <option value="modelY">Model Y</option>
+                    <option value="juniper">Juniper</option>
                     <option value="modelS">Model S</option>
                     <option value="modelX">Model X</option>
                     <option value="cybertruck">Cybertruck</option>

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -218,6 +218,7 @@ document.addEventListener('DOMContentLoaded', () => {
   initChangelogModal();
   loadDefaultPaths();
   applyDriveLineColors();
+  updatePrivacyZoneLayer(); // zone markers are permanent map landmarks
   logAction(`ui ready — units=${unitSystem}, marker=${markerType}, mapLayer=${localStorage.getItem('mapLayer') || 'Light'}`);
 });
 
@@ -461,6 +462,18 @@ function initMap() {
       layout: { 'line-join': 'round', 'line-cap': 'round' },
       paint: { 'line-color': ['get', 'color'], 'line-opacity': 0.95, 'line-width': SELECTED_LINE_WIDTH, 'line-dasharray': [1.6, 1] },
     });
+    // Privacy zone circles (Settings → Privacy) — visible only while that
+    // tab is open or a zone is being placed. Amber, distinct from the route
+    // palette.
+    map.addSource('privacy-zones', { type: 'geojson', data: EMPTY_FC });
+    map.addLayer({
+      id: 'privacy-zones-fill', type: 'fill', source: 'privacy-zones',
+      paint: { 'fill-color': '#f59e0b', 'fill-opacity': 0.12 },
+    });
+    map.addLayer({
+      id: 'privacy-zones-line', type: 'line', source: 'privacy-zones',
+      paint: { 'line-color': '#f59e0b', 'line-width': 2, 'line-dasharray': [2, 1.5], 'line-opacity': 0.8 },
+    });
     // City/street labels above every drive line (transparent overlay tiles).
     map.addLayer({ id: 'labels-overlay', type: 'raster', source: 'labels-overlay' });
     mapReady = true;
@@ -497,8 +510,56 @@ function initMap() {
   // features come back topmost-first, so the selected drive's own line wins
   // over dimmed context lines (clicking it toggles the selection off, same
   // as clicking the drive in the list).
+  // Privacy-zone placement. Aim: the preview follows the cursor and dragging
+  // pans the map as normal. Confirm: grabbing the circle's edge (anywhere on
+  // the ring) resizes the zone — preventDefault on that mousedown keeps the
+  // map still for the gesture, everywhere else still pans.
+  map.on('mousemove', (e) => {
+    const p = zonePlacement;
+    if (!p || !mapReady) return;
+    if (p.stage === 'aim') {
+      p.center = { lat: e.lngLat.lat, lng: e.lngLat.lng };
+      zonePlacementPreview();
+    } else if (p.stage === 'confirm') {
+      if (p.ringDrag) {
+        const gm = window.driveCalc?.geodesicM;
+        if (gm) {
+          p.radiusM = Math.min(5000, Math.max(10, gm(p.center.lat, p.center.lng, e.lngLat.lat, e.lngLat.lng)));
+        }
+        zoneConfirmHint();
+        zonePlacementPreview();
+      } else {
+        map.getCanvas().style.cursor = zoneNearRing(e) ? 'ew-resize' : '';
+      }
+    }
+  });
+  map.on('mousedown', (e) => {
+    const p = zonePlacement;
+    if (!p || p.stage !== 'confirm' || !p.center) return;
+    if (zoneNearRing(e)) {
+      p.ringDrag = true;
+      e.preventDefault(); // hold the map still while resizing
+    }
+  });
+  map.on('mouseup', () => {
+    if (zonePlacement?.ringDrag) zonePlacement.ringDrag = false;
+  });
+  document.getElementById('btn-zone-save').addEventListener('click', () => endZonePlacement(true));
+  document.getElementById('btn-zone-cancel').addEventListener('click', () => endZonePlacement(false));
+
   map.on('click', (e) => {
     if (!mapReady) return;
+    // Aim stage: a plain click (never a pan — MapLibre suppresses click after
+    // dragging) drops the pin and opens the editor. Any other placement stage
+    // swallows clicks so they can't select drives underneath the preview.
+    if (zonePlacement) {
+      if (zonePlacement.stage === 'aim') {
+        zonePlacement.center = { lat: e.lngLat.lat, lng: e.lngLat.lng };
+        zonePlacementPreview();
+        enterZoneConfirm();
+      }
+      return;
+    }
     const TOL_PX = 10;
     const box = [
       [e.point.x - TOL_PX, e.point.y - TOL_PX],
@@ -553,13 +614,17 @@ function initFooter() {
   document.getElementById('btn-settings').addEventListener('click', () => {
     document.getElementById('settings-overlay').classList.remove('hidden');
     refreshTessieStatus();
+    renderPrivacyZones();
+    setPrivacyZonesVisible(document.querySelector('.settings-tab-btn.active')?.dataset.stab === 'privacy');
   });
   document.getElementById('btn-close-settings').addEventListener('click', () => {
     document.getElementById('settings-overlay').classList.add('hidden');
+    setPrivacyZonesVisible(false);
   });
   document.getElementById('settings-overlay').addEventListener('click', (e) => {
     if (e.target === e.currentTarget) {
       document.getElementById('settings-overlay').classList.add('hidden');
+      setPrivacyZonesVisible(false);
     }
   });
 
@@ -572,7 +637,40 @@ function initFooter() {
       document.querySelectorAll('.settings-pane').forEach((p) => p.classList.remove('active'));
       btn.classList.add('active');
       document.getElementById(`stab-${stab}`).classList.add('active');
+      setPrivacyZonesVisible(stab === 'privacy'); // zone circles preview on the map
     });
+  });
+
+  // Privacy zones: add-custom-location + initial rows
+  document.getElementById('btn-add-zone').addEventListener('click', () => {
+    privacyZones.push({ id: `zone-${Date.now()}`, kind: 'custom', name: 'Custom location', lat: null, lng: null, radiusM: 150 });
+    savePrivacyZones();
+    renderPrivacyZones();
+  });
+  renderPrivacyZones();
+
+  // Zone icon picker: build the Material Symbols grid once; clicks route to
+  // whichever zone opened the popover.
+  const zoneIconGrid = document.querySelector('#zone-icon-popup .zone-icon-grid');
+  zoneIconGrid.innerHTML = ZONE_ICON_CHOICES.map((n) =>
+    `<button class="zone-icon-choice" data-icon="${n}" type="button" title="${n.replace(/_/g, ' ')}"><span class="material-icons">${n}</span></button>`
+  ).join('');
+  zoneIconGrid.addEventListener('click', (e) => {
+    const btn = e.target.closest('.zone-icon-choice');
+    if (!btn || !zoneIconPickerTarget) return;
+    zoneIconPickerTarget.icon = btn.dataset.icon;
+    savePrivacyZones();
+    renderPrivacyZones();
+    updatePrivacyZoneLayer();
+    closeZoneIconPicker();
+  });
+  document.addEventListener('click', (e) => {
+    if (zoneIconPickerTarget && !e.target.closest('#zone-icon-popup') && !e.target.closest('.zone-icon-btn')) {
+      closeZoneIconPicker();
+    }
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && zoneIconPickerTarget) closeZoneIconPicker();
   });
 
   // ── Integrations tab: Tessie (inline connect/auth) ─────────────────────
@@ -954,6 +1052,15 @@ function initFooter() {
     applyFsdMarkerVisibility();
   });
 
+  // Zone markers setting (default: on; editing sessions always show them)
+  const zoneMarkersChk = document.getElementById('chk-show-zone-markers');
+  zoneMarkersChk.checked = showZoneMarkers;
+  zoneMarkersChk.addEventListener('change', () => {
+    showZoneMarkers = zoneMarkersChk.checked;
+    localStorage.setItem('showZoneMarkers', String(showZoneMarkers));
+    updatePrivacyZoneLayer();
+  });
+
   // Support → Logs: save the main-process log buffer as a .txt via save dialog.
   const logsBtn = document.getElementById('btn-download-logs');
   if (logsBtn) {
@@ -1022,6 +1129,7 @@ function initFooter() {
     localStorage.setItem('unitSystem', unitSystem);
     syncUnitToggleActive();
     refreshUnitDisplay();
+    renderPrivacyZones(); // radius inputs re-label ft/m
   });
 
   // Auto-check on launch
@@ -1217,7 +1325,7 @@ function applyUpdateStatus({ status, version, percent, message }) {
       }
 
       // Show footer download button, flashing yellow until acted on
-      footerBtn.classList.remove('hidden');
+      footerBtn.classList.remove('hidden', 'update-downloading', 'update-ready');
       footerBtn.classList.add('update-attention');
       footerBtn.disabled = false;
       footerBtn.title = `Download v${version}`;
@@ -1233,6 +1341,7 @@ function applyUpdateStatus({ status, version, percent, message }) {
       msg.className = 'settings-update-msg update-current';
 
       footerBtn.classList.add('hidden');
+      footerBtn.classList.remove('update-attention', 'update-downloading', 'update-ready');
       break;
 
     case 'downloading':
@@ -1242,9 +1351,13 @@ function applyUpdateStatus({ status, version, percent, message }) {
       msg.textContent = `Downloading update…`;
       msg.className = 'settings-update-msg update-available';
 
-      footerBtn.classList.remove('update-attention');
+      // Animated download icon while the bytes come in (the % is in the
+      // tooltip — the 26px button has no room for text).
+      footerBtn.classList.remove('hidden', 'update-attention', 'update-ready');
+      footerBtn.classList.add('update-downloading');
       footerBtn.disabled = true;
       footerBtn.title = `Downloading… ${percent}%`;
+      footerBtn.querySelector('.material-icons').textContent = 'download';
       break;
 
     case 'ready':
@@ -1254,6 +1367,9 @@ function applyUpdateStatus({ status, version, percent, message }) {
       msg.textContent = 'Update downloaded. Restart to apply.';
       msg.className = 'settings-update-msg update-available';
 
+      // Orange + flashing until the user restarts.
+      footerBtn.classList.remove('hidden', 'update-attention', 'update-downloading');
+      footerBtn.classList.add('update-ready');
       footerBtn.disabled = false;
       footerBtn.title = 'Restart to Update';
       footerBtn.querySelector('.material-icons').textContent = 'restart_alt';
@@ -1268,6 +1384,7 @@ function applyUpdateStatus({ status, version, percent, message }) {
       msg.className = 'settings-update-msg update-error';
 
       footerBtn.classList.add('hidden');
+      footerBtn.classList.remove('update-attention', 'update-downloading', 'update-ready');
       break;
   }
 }
@@ -1687,6 +1804,60 @@ function initViewDrivesTab() {
       // renderOverviewOnMap() clears all layers and rebuilds from `drives`.
       // Without this the line lingered until the next map render (e.g. selecting
       // another drive).
+      renderOverviewOnMap();
+      renderDriveStats(drives, { totalRoutes: 0, processedFileCount: 0 });
+      updateTessieButtonStates();
+    } finally {
+      hideLoading();
+    }
+  });
+
+  // ── Multi-select action bar + shared bulk-removal confirm ──
+  // The confirm modal is shared with privacy-zone culls: callers queue
+  // targets + message via openBulkRemoveModal, the confirm here executes.
+  const removeDrivesOverlay = document.getElementById('remove-drives-overlay');
+  document.getElementById('btn-multi-clear').addEventListener('click', clearMultiSelect);
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && multiSelected.size) clearMultiSelect();
+  });
+  document.getElementById('btn-multi-remove').addEventListener('click', () => {
+    if (!multiSelected.size || !loadedFilePath) return;
+    const byId = new Map(drives.map((d) => [String(d.id), d]));
+    const targets = [...multiSelected].map((id) => byId.get(id)).filter(Boolean);
+    if (!targets.length) { clearMultiSelect(); return; }
+    openBulkRemoveModal(targets,
+      `Remove the ${targets.length} selected drive${targets.length === 1 ? '' : 's'}? This cannot be undone.`);
+  });
+  document.getElementById('btn-remove-drives-cancel').addEventListener('click', () => {
+    pendingBulkRemove = null;
+    removeDrivesOverlay.classList.add('hidden');
+  });
+  removeDrivesOverlay.addEventListener('click', (e) => {
+    if (e.target === removeDrivesOverlay) {
+      pendingBulkRemove = null;
+      removeDrivesOverlay.classList.add('hidden');
+    }
+  });
+  document.getElementById('btn-remove-drives-confirm').addEventListener('click', async () => {
+    removeDrivesOverlay.classList.add('hidden');
+    const targets = pendingBulkRemove ?? [];
+    pendingBulkRemove = null;
+    if (!targets.length || !loadedFilePath) return;
+    // One IPC round-trip removes the whole batch in a single file rewrite;
+    // the overlay covers the rewrite AND the list/map re-render after.
+    showLoading(`Removing ${targets.length} drive${targets.length === 1 ? '' : 's'}…`);
+    try {
+      const result = await window.electronAPI.removeDrives({
+        filePath: loadedFilePath,
+        driveStartTimes: targets.map((d) => d.startTime),
+      });
+      if (!result.success) { alert(`Failed to remove drives:\n${result.error}`); return; }
+      if (targets.some((d) => d.id === selectedDriveId)) deselectDrive();
+      const removed = new Set(targets.map((d) => d.startTime));
+      drives = drives.filter((d) => !removed.has(d.startTime));
+      logAction(`removed ${targets.length} drive(s) via bulk remove`);
+      await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      renderDriveList(drives); // also clears any multi-selection
       renderOverviewOnMap();
       renderDriveStats(drives, { totalRoutes: 0, processedFileCount: 0 });
       updateTessieButtonStates();
@@ -2455,9 +2626,9 @@ async function repairGPS() {
     if (result.routedGaps > 0) msgs.push(`Bridged ${result.routedGaps} gap(s) with road routes`);
     const straightGaps = result.bridgedGaps - (result.routedGaps ?? 0);
     if (straightGaps > 0) msgs.push(`Bridged ${straightGaps} gap(s) with straight lines`);
-    alert(msgs.length > 0 ? `Repair complete:\n${msgs.join('\n')}` : 'No issues found.');
 
-    // Reload the repaired file
+    // Reload the repaired file first so the summary can say WHICH drives
+    // carry bridges (they also get a "Bridged" chip in the list).
     showLoading();
     const reloaded = await window.electronAPI.loadAndGroupDrives(loadedFilePath);
     if (reloaded.success) {
@@ -2470,6 +2641,20 @@ async function repairGPS() {
       renderOverviewOnMap();
     }
     hideLoading();
+
+    const bridgedDrives = drives.filter((d) => d.bridged);
+    if (result.bridgedGaps > 0 && bridgedDrives.length > 0) {
+      msgs.push('');
+      msgs.push(`${bridgedDrives.length} drive(s) contain bridges — marked with a "Bridged" chip in the list:`);
+      const sample = bridgedDrives.slice(0, 8);
+      for (const d of sample) {
+        msgs.push(`  • ${new Date(d.startTime).toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}`);
+      }
+      if (bridgedDrives.length > sample.length) {
+        msgs.push(`  • …and ${bridgedDrives.length - sample.length} more`);
+      }
+    }
+    alert(msgs.length > 0 ? `Repair complete:\n${msgs.join('\n')}` : 'No issues found.');
   } finally {
     if (removeProgressListener) removeProgressListener();
     btn.textContent = 'Check Drives';
@@ -2825,7 +3010,7 @@ function renderDriveStats(drives, meta) {
     <div class="map-stat"><span class="map-stat-val">${fmt(drives.length)}</span><span class="map-stat-lbl">Drives</span></div>
     <div class="map-stat"><span class="map-stat-val">${fmt(distVal(totalMi, 0))}</span><span class="map-stat-lbl">${distLong()} Driven</span></div>
     <div class="map-stat"><span class="map-stat-val">${durStr}</span><span class="map-stat-lbl">Time Driving</span></div>
-    <div class="map-stat"><span class="map-stat-val" style="color:${fsdScoreColor(fsdScore)}">${fsdScore}%</span><span class="map-stat-lbl">FSD Score</span></div>
+    <div class="map-stat"><span class="map-stat-val" style="color:${seiDistM > 0 ? fsdScoreColor(fsdScore) : 'var(--text-dim)'}">${seiDistM > 0 ? `${fsdScore}%` : '—'}</span><span class="map-stat-lbl">FSD Score</span></div>
   `;
   if (apPct > 0) summary += `<div class="map-stat"><span class="map-stat-val">${apPct}%</span><span class="map-stat-lbl">Autopilot</span></div>`;
 
@@ -2919,10 +3104,408 @@ let _driveListRenderSeq = 0;
 // a frame between them so the UI stays responsive and the list fills in
 // progressively. Small lists (< one batch) still render in a single synchronous
 // pass — no behavior change for the common case.
+// ─── Privacy zones ───────────────────────────────────────────────────────────
+// Circles around Home / Work / custom spots (Settings → Privacy) used to cull
+// drives that start or end inside them. Zones live ONLY in localStorage —
+// drive-data.json is shared/exported between installs and must never carry
+// home coordinates.
+const ZONE_ICONS = { home: 'home', work: 'work', custom: 'place' };
+// Curated Material Symbols a zone can use (the vendored font is the full
+// ligature set, so any of these render). Kept to names that read at 15px.
+const ZONE_ICON_CHOICES = [
+  'home', 'work', 'place', 'school', 'fitness_center', 'restaurant',
+  'local_cafe', 'shopping_cart', 'storefront', 'local_hospital', 'church',
+  'park', 'sports_soccer', 'apartment', 'factory', 'star', 'favorite',
+  'pets', 'directions_car', 'flight',
+];
+const M_PER_FT = 0.3048;
+
+function zoneIcon(zone) {
+  return zone.icon ?? ZONE_ICONS[zone.kind] ?? 'place';
+}
+let privacyZones = loadPrivacyZones();
+let privacyZonesVisible = false;   // circles show while the Privacy tab is open
+// Map UI setting: zone markers as permanent landmarks (they always show while
+// the Privacy tab is open or a zone is being placed, regardless).
+let showZoneMarkers = localStorage.getItem('showZoneMarkers') !== 'false';
+const zoneMarkers = [];            // DOM icon markers at zone centers
+// Placement session ("Set on map"): aim → the preview circle follows the
+// cursor; mousedown locks the center and dragging sizes the radius; mouseup
+// enters confirm, where Save/Cancel in the hint bar completes the edit.
+let zonePlacement = null;          // { zone, stage:'aim'|'drag'|'confirm', center, radiusM, marker }
+// Shared bulk-removal confirm (multi-select bar + zone culls): callers queue
+// targets here, the modal's confirm handler executes them.
+let pendingBulkRemove = null;
+
+function loadPrivacyZones() {
+  let zones = [];
+  try {
+    const saved = JSON.parse(localStorage.getItem('privacyZones') || '[]');
+    if (Array.isArray(saved)) {
+      zones = saved.filter((z) => z && z.id && z.kind && typeof z.radiusM === 'number');
+    }
+  } catch { /* corrupted setting — start clean */ }
+  // Icon names go into innerHTML as ligature text — only accept safe names.
+  for (const z of zones) {
+    if (typeof z.icon !== 'string' || !/^[a-z0-9_]{1,40}$/.test(z.icon)) delete z.icon;
+  }
+  // Home and Work rows always exist, even before a location is set.
+  for (const kind of ['home', 'work']) {
+    if (!zones.some((z) => z.kind === kind)) {
+      zones.push({ id: kind, kind, name: kind === 'home' ? 'Home' : 'Work', lat: null, lng: null, radiusM: 150 });
+    }
+  }
+  const rank = (z) => (z.kind === 'home' ? 0 : z.kind === 'work' ? 1 : 2);
+  zones.sort((a, b) => rank(a) - rank(b));
+  return zones;
+}
+
+function savePrivacyZones() {
+  localStorage.setItem('privacyZones', JSON.stringify(privacyZones));
+}
+
+function openBulkRemoveModal(targets, msg) {
+  if (!targets.length) return;
+  pendingBulkRemove = targets;
+  document.getElementById('remove-drives-modal-msg').textContent = msg;
+  document.getElementById('remove-drives-overlay').classList.remove('hidden');
+}
+
+// Approximate the zone as a 64-gon — plenty round at map scale.
+function zoneCircleFeature(z) {
+  const latR = z.radiusM / 111320;
+  const lngR = z.radiusM / (111320 * Math.max(0.2, Math.cos((z.lat * Math.PI) / 180)));
+  const ring = [];
+  for (let i = 0; i <= 64; i++) {
+    const t = (i / 64) * 2 * Math.PI;
+    ring.push([z.lng + lngR * Math.sin(t), z.lat + latR * Math.cos(t)]);
+  }
+  return { type: 'Feature', properties: { zoneId: z.id }, geometry: { type: 'Polygon', coordinates: [ring] } };
+}
+
+function setPrivacyZonesVisible(v) {
+  privacyZonesVisible = v;
+  updatePrivacyZoneLayer();
+}
+
+function makeZoneMarkerEl(zone) {
+  const el = document.createElement('div');
+  el.className = 'zone-marker';
+  el.innerHTML = `<span class="material-icons">${zoneIcon(zone)}</span>`;
+  return el;
+}
+
+function updatePrivacyZoneLayer() {
+  whenMapReady(() => {
+    for (const m of zoneMarkers) m.remove();
+    zoneMarkers.length = 0;
+    // The zone being placed is drawn by the placement preview instead.
+    const zones = privacyZones.filter((z) => z.lat != null && z !== zonePlacement?.zone);
+    // Markers are permanent landmarks on the map (unless hidden in Map UI
+    // settings — editing sessions always show them); the dashed circles only
+    // show while the Privacy tab is open or a zone is being placed.
+    map.getSource('privacy-zones').setData({
+      type: 'FeatureCollection',
+      features: privacyZonesVisible ? zones.map(zoneCircleFeature) : [],
+    });
+    if (showZoneMarkers || privacyZonesVisible) {
+      for (const z of zones) {
+        zoneMarkers.push(new maplibregl.Marker({ element: makeZoneMarkerEl(z), anchor: 'center' })
+          .setLngLat([z.lng, z.lat])
+          .addTo(map));
+      }
+    }
+  });
+}
+
+function renderPrivacyZones() {
+  const listEl = document.getElementById('privacy-zones-list');
+  if (!listEl) return;
+  listEl.innerHTML = '';
+  const imperial = unitSystem === 'imperial';
+  const unitLbl = imperial ? 'ft' : 'm';
+  for (const z of privacyZones) {
+    const set = z.lat != null && z.lng != null;
+    const radiusDisplay = imperial ? Math.round(z.radiusM / M_PER_FT) : Math.round(z.radiusM);
+    const row = document.createElement('div');
+    row.className = 'zone-row';
+    row.innerHTML = `
+      <div class="zone-row-main">
+        <button class="zone-icon-btn" type="button" title="Change icon"><span class="material-icons">${zoneIcon(z)}</span></button>
+        ${z.kind === 'custom'
+          ? `<input class="zone-name-input" type="text" maxlength="24" value="${escapeHtml(z.name)}" />`
+          : `<span class="zone-name">${escapeHtml(z.name)}</span>`}
+        <span class="zone-coords">${set ? `${z.lat.toFixed(5)}, ${z.lng.toFixed(5)}` : 'Not set'}</span>
+      </div>
+      <div class="zone-row-actions">
+        ${set ? `<span class="zone-radius-text">Radius ${radiusDisplay} ${unitLbl}</span>` : ''}
+        <button class="zone-btn zone-set" type="button">${set ? 'Edit on map' : 'Set on map'}</button>
+        <button class="zone-btn zone-cull" type="button" ${set ? '' : 'disabled'}>Cull drives</button>
+        <button class="zone-btn zone-remove" type="button" title="${z.kind === 'custom' ? 'Delete zone' : 'Clear location'}">
+          <span class="material-icons">${z.kind === 'custom' ? 'delete' : 'backspace'}</span>
+        </button>
+      </div>`;
+
+    const nameInput = row.querySelector('.zone-name-input');
+    if (nameInput) {
+      nameInput.addEventListener('change', () => {
+        z.name = nameInput.value.trim() || 'Custom location';
+        nameInput.value = z.name;
+        savePrivacyZones();
+      });
+    }
+    row.querySelector('.zone-icon-btn').addEventListener('click', (e) => {
+      e.stopPropagation();
+      openZoneIconPicker(e.currentTarget, z);
+    });
+    row.querySelector('.zone-set').addEventListener('click', () => beginZoneMapPick(z));
+    row.querySelector('.zone-cull').addEventListener('click', () => cullZoneDrives(z));
+    row.querySelector('.zone-remove').addEventListener('click', () => {
+      if (z.kind === 'custom') privacyZones = privacyZones.filter((x) => x.id !== z.id);
+      else { z.lat = null; z.lng = null; }
+      savePrivacyZones();
+      renderPrivacyZones();
+      updatePrivacyZoneLayer();
+    });
+    listEl.appendChild(row);
+  }
+}
+
+function zoneRadiusLabel(radiusM) {
+  return unitSystem === 'imperial' ? `${Math.round(radiusM / M_PER_FT)} ft` : `${Math.round(radiusM)} m`;
+}
+
+// Small popover with the curated Material Symbols grid; picking one changes
+// the zone's icon in the settings row and on its map marker.
+let zoneIconPickerTarget = null;
+
+function openZoneIconPicker(anchor, zone) {
+  const popup = document.getElementById('zone-icon-popup');
+  if (!popup.classList.contains('hidden') && zoneIconPickerTarget === zone) {
+    closeZoneIconPicker();
+    return;
+  }
+  zoneIconPickerTarget = zone;
+  popup.querySelectorAll('.zone-icon-choice').forEach((b) => {
+    b.classList.toggle('active', b.dataset.icon === zoneIcon(zone));
+  });
+  const rect = anchor.getBoundingClientRect();
+  popup.style.top = `${rect.bottom + 6}px`;
+  popup.style.left = `${Math.min(rect.left, window.innerWidth - 240)}px`;
+  popup.classList.remove('hidden');
+}
+
+function closeZoneIconPicker() {
+  document.getElementById('zone-icon-popup').classList.add('hidden');
+  zoneIconPickerTarget = null;
+}
+
+function setPickHint(text, confirm) {
+  const hint = document.getElementById('map-pick-hint');
+  document.getElementById('map-pick-hint-text').textContent = text;
+  document.getElementById('map-pick-actions').classList.toggle('hidden', !confirm);
+  hint.classList.toggle('confirm', confirm);
+  hint.classList.remove('hidden');
+}
+
+// "Set on map" / "Edit on map": hide the settings modal and start a placement
+// session. In 'aim', the preview follows the cursor, dragging PANS the map
+// (MapLibre suppresses the click after a pan, so panning never places), and a
+// plain click drops the pin. That enters the editable confirm stage: drag the
+// pin to move the zone, drag anywhere on the circle's edge to resize it.
+// Save/Cancel completes; Esc cancels at any point.
+function beginZoneMapPick(zone) {
+  document.getElementById('settings-overlay').classList.add('hidden');
+  const isSet = zone.lat != null && zone.lng != null;
+  zonePlacement = {
+    zone,
+    stage: isSet ? 'confirm' : 'aim',
+    center: isSet ? { lat: zone.lat, lng: zone.lng } : null,
+    radiusM: Math.max(10, zone.radiusM),
+    marker: null,
+    ringDrag: false,
+  };
+  setPrivacyZonesVisible(true); // other zones stay visible for context
+  whenMapReady(() => {
+    if (isSet) {
+      // Bring the zone on screen with breathing room, then hand over the
+      // move/resize handles.
+      const latPad = (zone.radiusM * 1.8) / 111320;
+      const lngPad = (zone.radiusM * 1.8) / (111320 * Math.max(0.2, Math.cos((zone.lat * Math.PI) / 180)));
+      map.fitBounds(
+        [[zone.lng - lngPad, zone.lat - latPad], [zone.lng + lngPad, zone.lat + latPad]],
+        { duration: 500 },
+      );
+      zonePlacementPreview();
+      enterZoneConfirm();
+    } else {
+      map.getCanvas().style.cursor = 'crosshair';
+      setPickHint(`Click to place "${zone.name}" — drag to pan the map. Esc to cancel`, false);
+    }
+  });
+}
+
+// Point on the circle's eastern edge — used to measure the ring's pixel radius.
+function zoneEdgeLngLat(center, radiusM) {
+  const lngR = radiusM / (111320 * Math.max(0.2, Math.cos((center.lat * Math.PI) / 180)));
+  return [center.lng + lngR, center.lat];
+}
+
+// Is the mouse on the zone's edge ring (within a grab tolerance, in pixels)?
+function zoneNearRing(e) {
+  const p = zonePlacement;
+  if (!p?.center) return false;
+  const c = map.project([p.center.lng, p.center.lat]);
+  const edge = map.project(zoneEdgeLngLat(p.center, p.radiusM));
+  const radiusPx = Math.hypot(edge.x - c.x, edge.y - c.y);
+  const distPx = Math.hypot(e.point.x - c.x, e.point.y - c.y);
+  return Math.abs(distPx - radiusPx) <= 8;
+}
+
+function zoneConfirmHint() {
+  const p = zonePlacement;
+  if (!p) return;
+  setPickHint(`"${p.zone.name}" — Radius ${zoneRadiusLabel(p.radiusM)}. Drag the pin to move it, or drag the circle's edge to resize.`, true);
+}
+
+// Editable confirm stage: draggable center pin; the circle's edge itself is
+// the resize handle (see the mousedown/mousemove ring-drag in initMap).
+function enterZoneConfirm() {
+  const p = zonePlacement;
+  if (!p || !p.center) return;
+  p.stage = 'confirm';
+  map.getCanvas().style.cursor = '';
+
+  if (!p.marker) zonePlacementPreview(); // ensures the pin exists
+  p.marker.getElement().classList.add('zone-marker--live');
+  p.marker.setDraggable(true);
+  p.marker.on('drag', () => {
+    const ll = p.marker.getLngLat();
+    p.center = { lat: ll.lat, lng: ll.lng };
+    zonePlacementPreview();
+  });
+
+  zoneConfirmHint();
+}
+
+// Redraw the placement preview (staged circle + marker at the staged center).
+function zonePlacementPreview() {
+  const p = zonePlacement;
+  if (!p || !mapReady || !p.center) return;
+  const others = privacyZones
+    .filter((z) => z.lat != null && z !== p.zone)
+    .map(zoneCircleFeature);
+  others.push(zoneCircleFeature({ radiusM: p.radiusM, lat: p.center.lat, lng: p.center.lng, id: p.zone.id }));
+  map.getSource('privacy-zones').setData({ type: 'FeatureCollection', features: others });
+  if (!p.marker) {
+    const el = makeZoneMarkerEl(p.zone);
+    p.marker = new maplibregl.Marker({ element: el, anchor: 'center' })
+      .setLngLat([p.center.lng, p.center.lat])
+      .addTo(map);
+  } else {
+    p.marker.setLngLat([p.center.lng, p.center.lat]);
+  }
+}
+
+function endZonePlacement(save) {
+  const p = zonePlacement;
+  if (!p) return;
+  if (save && p.center) {
+    p.zone.lat = p.center.lat;
+    p.zone.lng = p.center.lng;
+    p.zone.radiusM = Math.round(p.radiusM);
+    savePrivacyZones();
+    logAction(`privacy zone "${p.zone.name}" placed (radius ${Math.round(p.zone.radiusM)} m)`);
+  }
+  if (p.marker) p.marker.remove();
+  zonePlacement = null;
+  document.getElementById('map-pick-hint').classList.add('hidden');
+  if (mapReady) map.getCanvas().style.cursor = '';
+  renderPrivacyZones();
+  updatePrivacyZoneLayer();
+  document.getElementById('settings-overlay').classList.remove('hidden');
+}
+
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape' && zonePlacement) endZonePlacement(false);
+});
+
+// Find drives whose start OR end point falls inside the zone and queue them
+// for the shared bulk-removal confirm. Uses the same WGS-84 geodesic as the
+// drive stats, against the grouper's snapped endpoints.
+function cullZoneDrives(zone) {
+  if (zone.lat == null || zone.lng == null) return;
+  if (!loadedFilePath || !drives.length) {
+    alert('Load a drive data file first.');
+    return;
+  }
+  const gm = window.driveCalc?.geodesicM;
+  if (!gm) { alert('Distance helper unavailable.'); return; }
+  const matches = drives.filter((d) => ['origin', 'dest'].some((role) => {
+    const c = endpointCoord(d, role);
+    return c && gm(zone.lat, zone.lng, c.lat, c.lng) <= zone.radiusM;
+  }));
+  if (!matches.length) {
+    alert(`No drives start or end inside "${zone.name}".`);
+    return;
+  }
+  document.getElementById('settings-overlay').classList.add('hidden');
+  setPrivacyZonesVisible(false);
+  openBulkRemoveModal(matches,
+    `Remove ${matches.length} drive${matches.length === 1 ? '' : 's'} that start or end within "${zone.name}"? This cannot be undone.`);
+}
+
+// ─── Drive list multi-select ─────────────────────────────────────────────────
+// Ctrl/Cmd+click toggles a card; Shift+click selects the range from the last
+// toggle; Esc or the bar's X clears. Selection is cleared on every list
+// re-render (reload, tag filter, removal) so it can never reference stale
+// cards. Ids are kept as strings to match dataset.driveId.
+const multiSelected = new Set();
+let multiAnchorId = null;      // shift-range anchor (last toggled card)
+let lastRenderedOrder = [];    // drive ids in the currently displayed order
+
+function toggleMultiSelect(id) {
+  if (multiSelected.has(id)) multiSelected.delete(id);
+  else multiSelected.add(id);
+  multiAnchorId = id;
+  syncMultiSelectUI();
+}
+
+function rangeMultiSelect(id) {
+  const a = multiAnchorId == null ? -1 : lastRenderedOrder.indexOf(multiAnchorId);
+  const b = lastRenderedOrder.indexOf(id);
+  if (a === -1 || b === -1) { toggleMultiSelect(id); return; }
+  for (let i = Math.min(a, b); i <= Math.max(a, b); i++) multiSelected.add(lastRenderedOrder[i]);
+  syncMultiSelectUI();
+}
+
+function clearMultiSelect() {
+  multiSelected.clear();
+  multiAnchorId = null;
+  syncMultiSelectUI();
+}
+
+function syncMultiSelectUI() {
+  document.querySelectorAll('.drive-item').forEach((el) => {
+    el.classList.toggle('multi-selected', multiSelected.has(el.dataset.driveId));
+  });
+  const bar = document.getElementById('multi-select-bar');
+  if (!bar) return;
+  if (multiSelected.size) {
+    document.getElementById('multi-select-count').textContent =
+      `${multiSelected.size} drive${multiSelected.size === 1 ? '' : 's'} selected`;
+    bar.classList.remove('hidden');
+  } else {
+    bar.classList.add('hidden');
+  }
+}
+
 async function renderDriveList(drives) {
   const seq = ++_driveListRenderSeq;
   const list = document.getElementById('drives-list');
   list.innerHTML = '';
+  lastRenderedOrder = [];
+  clearMultiSelect();
 
   if (drives.length === 0) {
     list.innerHTML = '<div class="empty-state">No drives found in this file.</div>';
@@ -2934,6 +3517,7 @@ async function renderDriveList(drives) {
   if (activeTagFilter) {
     sorted = sorted.filter((d) => (d.tags ?? []).includes(activeTagFilter));
   }
+  lastRenderedOrder = sorted.map((d) => String(d.id));
 
   if (sorted.length === 0) {
     list.innerHTML = '<div class="empty-state">No drives match the selected filter.</div>';
@@ -3069,6 +3653,7 @@ function buildDriveItem(drive) {
       <span class="drive-chip"><span class="material-icons">straighten</span>${distVal(drive.distanceMi)} ${distShort()}</span>
       <span class="drive-chip"><span class="material-icons">schedule</span>${durStr}</span>
       ${fsdChip}
+      ${drive.bridged ? '<span class="drive-chip drive-chip--bridged" title="A GPS gap in this drive was bridged by Check Drives"><span class="material-icons">route</span>Bridged</span>' : ''}
     </div>
     <div class="drive-item-tags">
       ${tagPills}
@@ -3133,7 +3718,15 @@ function buildDriveItem(drive) {
     }
   });
 
-  item.addEventListener('click', () => selectDrive(drive));
+  // Shift+click builds a range selection — stop the browser text-selection
+  // that shift-clicking otherwise drags across the cards.
+  item.addEventListener('mousedown', (e) => { if (e.shiftKey) e.preventDefault(); });
+  item.addEventListener('click', (e) => {
+    if (e.ctrlKey || e.metaKey) { toggleMultiSelect(String(drive.id)); return; }
+    if (e.shiftKey) { rangeMultiSelect(String(drive.id)); return; }
+    if (multiSelected.size) clearMultiSelect(); // plain click exits select mode
+    selectDrive(drive);
+  });
 
   // Location pins: resolve start/end place names into the location line under
   // each Departed/Arrived header. Names cache on the drive object so re-renders

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -125,7 +125,9 @@ const VEHICLE_MODELS = {
   // Each box keeps its own art's canvas aspect so nothing warps (3/Y are
   // 1320x2118, X is 1320x2148); larger vehicles get proportionally larger boxes.
   model3:     { texture: '../../assets/map-ui/Model3_t.png',     mask: '../../assets/map-ui/Model3_c.png',     w: 56, h: 90  },
+  highland:   { texture: '../../assets/map-ui/Highland_t.png',   mask: '../../assets/map-ui/Highland_c.png',   w: 56, h: 90  },
   modelY:     { texture: '../../assets/map-ui/ModelY_t.png',     mask: '../../assets/map-ui/ModelY_c.png',     w: 56, h: 90  },
+  juniper:    { texture: '../../assets/map-ui/Juniper_t.png',    mask: '../../assets/map-ui/Juniper_c.png',    w: 56, h: 90  },
   modelS:     { texture: '../../assets/map-ui/ModelS_t.png',     mask: '../../assets/map-ui/ModelS_c.png',     w: 58, h: 93  },
   modelX:     { texture: '../../assets/map-ui/ModelX_t.png',     mask: '../../assets/map-ui/ModelX_c.png',     w: 58, h: 94  },
   cybertruck: { texture: '../../assets/map-ui/Cybertruck_t.png', mask: '../../assets/map-ui/Cybertruck_c.png', w: 64, h: 103 },
@@ -1667,19 +1669,30 @@ function initViewDrivesTab() {
     removeDriveOverlay.classList.add('hidden');
     const drive = pendingRemoveDrive;
     pendingRemoveDrive = null;
-    const result = await window.electronAPI.removeDrive({ filePath: loadedFilePath, driveStartTime: drive.startTime });
-    if (!result.success) return;
-    const wasSelected = selectedDriveId === drive.id;
-    drives = drives.filter((d) => d.startTime !== drive.startTime);
-    if (wasSelected) deselectDrive();
-    renderDriveList(drives);
-    // Redraw the map so the deleted drive's polyline is removed immediately —
-    // renderOverviewOnMap() clears all layers and rebuilds from `drives`.
-    // Without this the line lingered until the next map render (e.g. selecting
-    // another drive).
-    renderOverviewOnMap();
-    renderDriveStats(drives, { totalRoutes: 0, processedFileCount: 0 });
-    updateTessieButtonStates();
+    // Removing rewrites the whole drive-data.json — seconds on a large
+    // library — and the re-render afterwards blocks the renderer too. Keep
+    // the spinner overlay up for the whole stretch or the app looks frozen.
+    showLoading('Removing drive…');
+    try {
+      const result = await window.electronAPI.removeDrive({ filePath: loadedFilePath, driveStartTime: drive.startTime });
+      if (!result.success) return;
+      const wasSelected = selectedDriveId === drive.id;
+      drives = drives.filter((d) => d.startTime !== drive.startTime);
+      if (wasSelected) deselectDrive();
+      // Let the overlay paint one frame before the synchronous re-render
+      // briefly blocks the renderer (mirrors reloadDrivesAfterWrite).
+      await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      renderDriveList(drives);
+      // Redraw the map so the deleted drive's polyline is removed immediately —
+      // renderOverviewOnMap() clears all layers and rebuilds from `drives`.
+      // Without this the line lingered until the next map render (e.g. selecting
+      // another drive).
+      renderOverviewOnMap();
+      renderDriveStats(drives, { totalRoutes: 0, processedFileCount: 0 });
+      updateTessieButtonStates();
+    } finally {
+      hideLoading();
+    }
   });
 }
 
@@ -2208,11 +2221,14 @@ function initTessieImport() {
       lines.push('Click OK to delete these hidden drives from the file (recoverable from .bak).');
       lines.push('Click Cancel to keep them stored (they will stay hidden as long as SEI covers the same time).');
       if (confirm(lines.join('\n'))) {
+        // Same full-file rewrite as Remove Imported Drives — show the spinner.
+        showLoading('Removing hidden imported drives…');
         const cleanupResult = await svc().removeHidden();
         if (cleanupResult.success) {
           await reloadDrivesAfterWrite();
           alert(`Removed ${fmt(cleanupResult.removed)} hidden imported drive(s) from the file.`);
         } else {
+          hideLoading();
           alert(`Cleanup failed: ${cleanupResult.error}`);
         }
       }
@@ -2252,6 +2268,10 @@ function initTessieImport() {
     if (!loadedFilePath || (!wantTessie && !wantTeslascope)) return;
     const beforeCount = drives.length;
 
+    // Each removal rewrites the whole drive-data.json — seconds on a large
+    // library, and there can be two in a row. Keep the spinner overlay up so
+    // the app doesn't look frozen; reloadDrivesAfterWrite reuses it after.
+    showLoading('Removing imported drives…');
     let removed = 0;
     const failures = [];
     if (wantTessie) {
@@ -2265,6 +2285,7 @@ function initTessieImport() {
       else failures.push(`Teslascope: ${r.error}`);
     }
     if (failures.length === (wantTessie ? 1 : 0) + (wantTeslascope ? 1 : 0)) {
+      hideLoading();
       alert(`Failed to remove imported drives:\n${failures.join('\n')}`);
       return;
     }
@@ -2342,13 +2363,17 @@ async function updateRevertButton() {
 async function revertGPS() {
   if (!loadedFilePath) return;
 
+  // Restoring the .bak rewrites the whole drive-data.json — keep the spinner
+  // up from the first moment or the app looks frozen while it copies.
+  showLoading('Reverting to backup…');
   const result = await window.electronAPI.revertGPS(loadedFilePath);
   if (!result.success) {
+    hideLoading();
     alert(`Failed to revert:\n${result.error}`);
     return;
   }
 
-  // Reload
+  // Reload (updates the overlay text; hideLoading runs after the re-render)
   showLoading();
   const reloaded = await window.electronAPI.loadAndGroupDrives(loadedFilePath);
   if (reloaded.success) {
@@ -3330,17 +3355,29 @@ function makeDotMarker(latLng, { fill, radius = 7, strokeW = 2, opacity = 1, too
     el.style.justifyContent = 'center';
     // The letter lives in an inner span: el is anchored to the GPS point, so any
     // optical nudge has to move the glyph, not the circle.
+    const px = Math.round(radius * 1.7); // fill the circle
     const lbl = document.createElement('span');
     lbl.textContent = label;
     lbl.style.color = labelColor;
     lbl.style.fontFamily = "'Noto Sans', sans-serif";
     lbl.style.fontWeight = '800';
-    lbl.style.fontSize = `${Math.round(radius * 1.7)}px`; // fill the circle
+    lbl.style.fontSize = `${px}px`;
     lbl.style.lineHeight = '1';
     lbl.style.textShadow = '0 1px 2px rgba(0, 0, 0, 0.5)'; // legibility on any fill
-    // Capitals have no descender, so a flex-centered line box sits ~1-2px high;
-    // nudge the glyph down to optically center it in the circle.
-    lbl.style.transform = 'translateY(0.06em)';
+    // Flex centers the em BOX / advance width, not the ink: where the letter
+    // actually lands depends on the font's ascent/descent split and side
+    // bearings. Measure the real ink bounds on both axes and shift the ink
+    // center onto the box center — exact for whatever font actually loaded.
+    const ctx = (makeDotMarker._mctx ??= document.createElement('canvas').getContext('2d'));
+    ctx.font = `800 ${px}px 'Noto Sans', sans-serif`;
+    const m = ctx.measureText(label);
+    if (m.fontBoundingBoxAscent !== undefined) {
+      const dy = (m.actualBoundingBoxAscent - m.actualBoundingBoxDescent) / 2
+               - (m.fontBoundingBoxAscent - m.fontBoundingBoxDescent) / 2;
+      const dx = m.width / 2
+               - (m.actualBoundingBoxRight - m.actualBoundingBoxLeft) / 2;
+      lbl.style.transform = `translate(${dx.toFixed(2)}px, ${dy.toFixed(2)}px)`;
+    }
     el.appendChild(lbl);
   }
   if (tooltip) attachMapTooltip(el, tooltip);

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -376,7 +376,8 @@ input[type="date"].text-input::-webkit-calendar-picker-indicator:hover { opacity
    disabled stays the muted faded grey. Confirm-modal danger buttons and the
    processing Stop button are untouched. */
 #btn-revert-gps:not(:disabled):not(:hover),
-#btn-remove-tessie:not(:disabled):not(:hover) { color: var(--blue-light); }
+#btn-remove-tessie:not(:disabled):not(:hover),
+#btn-multi-remove:not(:hover) { color: var(--blue-light); }
 
 .btn-icon {
   padding: 7px 10px;
@@ -605,6 +606,61 @@ input[type="date"].text-input::-webkit-calendar-picker-indicator:hover { opacity
   background: linear-gradient(150deg, rgba(52, 211, 153, 0.18), rgba(52, 211, 153, 0.06) 60%, rgba(52, 211, 153, 0.1));
 }
 
+/* ── Drive multi-select (Ctrl/Shift+click) ─────────────────────────────── */
+/* Distinct from .selected (the single open drive): a solid accent ring
+   instead of the tinted wash, so both states can coexist readably. */
+.drive-item.multi-selected {
+  border-color: var(--accent);
+  box-shadow: inset 0 0 0 1px var(--accent);
+  background: rgba(52, 211, 153, 0.07);
+}
+
+#tab-drives { position: relative; }
+
+#multi-select-bar {
+  position: absolute;
+  bottom: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 8px 7px 12px;
+  border-radius: 12px;
+  background: var(--map-glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+  white-space: nowrap;
+}
+#multi-select-count {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+}
+#multi-select-bar .btn-danger {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 10px;
+  font-size: 12px;
+  border-radius: 9px;
+}
+#multi-select-bar .btn-danger .material-icons { font-size: 15px; }
+#btn-multi-clear {
+  display: inline-flex;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 2px;
+  line-height: 1;
+}
+#btn-multi-clear:hover { color: var(--text); }
+#btn-multi-clear .material-icons { font-size: 16px; }
+
 /* Horizontal journey — times (start ─┄─ end) across the top, then the
    Departed/Arrived labels, then the location names, each left ↔ right. */
 .drive-journey { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
@@ -692,6 +748,7 @@ input[type="date"].text-input::-webkit-calendar-picker-indicator:hover { opacity
 .drive-chip--green { background: rgba(16, 185, 129, 0.15); color: #34d399; border-color: rgba(16, 185, 129, 0.22); }
 .drive-chip--blue  { background: rgba(52, 211, 153, 0.15); color: var(--blue-light); border-color: rgba(52, 211, 153, 0.22); }
 .drive-chip--slate { background: rgba(255, 255, 255, 0.05); color: var(--text-muted); border-color: rgba(255, 255, 255, 0.1); }
+.drive-chip--bridged { background: rgba(251, 191, 36, 0.12); color: var(--warn); border-color: rgba(251, 191, 36, 0.25); }
 
 .drive-badge {
   display: inline-block;
@@ -1572,7 +1629,9 @@ input[type="date"].text-input::-webkit-calendar-picker-indicator:hover { opacity
 }
 
 #settings-modal {
-  width: 380px;
+  /* Wide enough for the five tab labels (General/Privacy/Map UI/Integrations/
+     Support) to sit comfortably on one row. */
+  width: 500px;
   max-height: 86vh;
   /* Match the FSD Stats panel's glass surface: translucent dark glass + sheen
      with a white translucent edge (the backdrop blur is on ::before). */
@@ -1628,7 +1687,8 @@ input[type="date"].text-input::-webkit-calendar-picker-indicator:hover { opacity
 
 .settings-tab-btn {
   flex: 1;
-  padding: 7px 12px;
+  padding: 7px 10px;
+  white-space: nowrap;
   background: transparent;
   border: none;
   border-radius: 9px;
@@ -1972,6 +2032,7 @@ input[type="date"].text-input::-webkit-calendar-picker-indicator:hover { opacity
 #check-drives-overlay,
 #revert-overlay,
 #remove-drive-overlay,
+#remove-drives-overlay,
 #tessie-overlay,
 #import-json-confirm-overlay,
 #remove-tessie-overlay {
@@ -2263,6 +2324,221 @@ input[type="date"].text-input::-webkit-calendar-picker-indicator:hover { opacity
   flex-shrink: 0;
 }
 .car-color-swatch:hover { border-color: var(--text-muted); }
+
+/* ── Privacy zones (Settings → Privacy) ─────────────────────────────────── */
+.privacy-zones-hint {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+.zone-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.04);
+}
+.zone-row + .zone-row { margin-top: 8px; }
+
+.zone-row-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.zone-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  color: var(--accent);
+  cursor: pointer;
+}
+.zone-icon-btn:hover { border-color: var(--glass-border); background: rgba(255, 255, 255, 0.06); }
+.zone-icon-btn .material-icons { font-size: 17px; }
+
+/* Icon picker popover (shared, anchored to the clicked zone row icon).
+   Dark-tinted glass + the ::before backdrop blur (popup-safe glass group) —
+   plain --card-bg let the settings text underneath bleed through. */
+#zone-icon-popup {
+  position: fixed;
+  z-index: 9600;
+  padding: 8px;
+  background: var(--map-glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: 12px;
+  box-shadow: var(--modal-shadow);
+}
+.zone-icon-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 34px);
+  gap: 4px;
+}
+.zone-icon-choice {
+  width: 34px;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.zone-icon-choice:hover { color: var(--text); background: rgba(255, 255, 255, 0.08); }
+.zone-icon-choice.active { color: var(--accent); border-color: var(--accent); background: rgba(52, 211, 153, 0.12); }
+.zone-icon-choice .material-icons { font-size: 18px; }
+.zone-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+.zone-name-input {
+  flex: 0 1 130px;
+  min-width: 0;
+  padding: 3px 7px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  background: var(--input-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+.zone-coords {
+  margin-left: auto;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.zone-row-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.zone-radius-text {
+  font-size: 12px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.zone-btn {
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.zone-btn:hover:not(:disabled) { color: var(--text); border-color: var(--text-muted); }
+.zone-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.zone-btn.zone-cull:hover:not(:disabled) { color: var(--danger); border-color: rgba(248, 113, 113, 0.45); }
+.zone-btn.zone-remove {
+  margin-left: auto;
+  padding: 4px 6px;
+  display: inline-flex;
+  border: none;
+}
+.zone-btn.zone-remove .material-icons { font-size: 15px; }
+.zone-btn.zone-remove:hover { color: var(--danger); }
+
+.btn-add-zone {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.btn-add-zone:hover { color: var(--accent); border-color: var(--accent); }
+.btn-add-zone .material-icons { font-size: 16px; }
+
+/* Zone center markers — amber disc with the zone's icon. pointer-events off
+   so the preview marker gliding under the cursor never swallows the map's
+   mousemove/mousedown during placement. */
+.zone-marker {
+  width: 26px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid #fff;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.5);
+  pointer-events: none;
+}
+.zone-marker .material-icons {
+  font-size: 15px;
+  color: #fff;
+}
+/* During the confirm/edit stage the pin becomes draggable. */
+.zone-marker--live {
+  pointer-events: auto;
+  cursor: grab;
+}
+.zone-marker--live:active { cursor: grabbing; }
+
+/* Floating hint bar while placing a zone center (text + Save/Cancel) */
+#map-pick-hint {
+  position: absolute;
+  top: 14px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #fbbf24;
+  background: var(--map-glass-bg);
+  border: 1px solid rgba(251, 191, 36, 0.4);
+  border-radius: 10px;
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+  white-space: nowrap;
+  pointer-events: none;
+}
+#map-pick-hint.confirm { pointer-events: auto; }
+#map-pick-actions { display: inline-flex; gap: 6px; }
+#map-pick-actions button {
+  padding: 4px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  border-radius: 7px;
+  cursor: pointer;
+}
+#btn-zone-save {
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  color: #06281c;
+}
+#btn-zone-save:hover { background: var(--accent-hover); border-color: var(--accent-hover); }
+#btn-zone-cancel {
+  background: transparent;
+  border: 1px solid var(--glass-border);
+  color: var(--text-muted);
+}
+#btn-zone-cancel:hover { color: var(--text); border-color: var(--text-muted); }
 
 /* Drive Line Colors group in Settings → Map UI → Customization */
 .settings-subhead {
@@ -2609,6 +2885,51 @@ input[type="date"].text-input::-webkit-calendar-picker-indicator:hover { opacity
   50%      { opacity: 0.55; box-shadow: 0 0 6px 2px rgba(250, 204, 21, 0.25); }
 }
 
+/* Downloading: the arrow travels down and fades, so the button reads as
+   active work rather than a static icon (the % stays in the tooltip). */
+.footer-update-btn.update-downloading {
+  border-color: var(--accent);
+  background: rgba(52, 211, 153, 0.12);
+  color: var(--accent);
+  opacity: 1; /* override the :disabled dimming — this state is live */
+  cursor: progress;
+}
+.footer-update-btn.update-downloading .material-icons {
+  animation: update-download-bob 1.15s ease-in-out infinite;
+}
+@keyframes update-download-bob {
+  0%   { transform: translateY(-5px); opacity: 0.15; }
+  45%  { transform: translateY(2px);  opacity: 1; }
+  70%  { transform: translateY(2px);  opacity: 1; }
+  100% { transform: translateY(-5px); opacity: 0.15; }
+}
+
+/* Ready to install: orange, flashing, until the user restarts. */
+.footer-update-btn.update-ready {
+  border-color: #fb923c;
+  background: rgba(251, 146, 60, 0.14);
+  color: #fb923c;
+  animation: update-ready-flash 1.1s ease-in-out infinite;
+}
+.footer-update-btn.update-ready:hover {
+  background: rgba(251, 146, 60, 0.28);
+  animation-play-state: paused;
+  opacity: 1;
+}
+@keyframes update-ready-flash {
+  0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(251, 146, 60, 0.5); }
+  50%      { opacity: 0.55; box-shadow: 0 0 7px 2px rgba(251, 146, 60, 0.3); }
+}
+
+/* Respect reduced-motion: keep the colour cues, drop the animation. */
+@media (prefers-reduced-motion: reduce) {
+  .footer-update-btn.update-attention,
+  .footer-update-btn.update-ready,
+  .footer-update-btn.update-downloading .material-icons {
+    animation: none;
+  }
+}
+
 /* ── Loading Overlay ───────────────────────────────────────────────────── */
 #loading-overlay {
   position: absolute;
@@ -2883,7 +3204,8 @@ input[type="date"].text-input::-webkit-calendar-picker-indicator:hover { opacity
 .reprocess-modal,
 #update-modal,
 #changelog-modal,
-#car-color-popup {
+#car-color-popup,
+#zone-icon-popup {
   isolation: isolate;
 }
 #settings-overlay::before,
@@ -2894,7 +3216,8 @@ input[type="date"].text-input::-webkit-calendar-picker-indicator:hover { opacity
 .reprocess-modal::before,
 #update-modal::before,
 #changelog-modal::before,
-#car-color-popup::before {
+#car-color-popup::before,
+#zone-icon-popup::before {
   content: '';
   position: absolute;
   inset: 0;
@@ -2916,7 +3239,8 @@ input[type="date"].text-input::-webkit-calendar-picker-indicator:hover { opacity
 .reprocess-modal::before,
 #update-modal::before,
 #changelog-modal::before,
-#car-color-popup::before {
+#car-color-popup::before,
+#zone-icon-popup::before {
   backdrop-filter: var(--glass-blur);
   -webkit-backdrop-filter: var(--glass-blur);
 }


### PR DESCRIPTION
## What this adds

**Privacy zones** — a new **Settings → Privacy** tab. Draw a circle around Home, Work, or any custom location, then cull every drive that starts or ends inside it in one confirmed sweep. Placement is on-map: a preview circle tracks the cursor (the map still pans normally), a click drops the pin, then the pin drags to move the zone and the circle's **edge** drags to resize it, with Save/Cancel confirming. "Edit on map" reopens the same editor on a placed zone.

**Drive multi-select** — Ctrl+click toggles, Shift+click selects a range, Esc clears. A floating bar shows the count and removes the batch via a new `remove-drives` IPC that does one read → one filter → **one file rewrite** for the whole selection, instead of a full rewrite per drive.

**Also in here**
- **Check Drives shows its work**: drives containing bridge routes get a "Bridged" chip, and the completion summary lists them. (Closes the long-standing "see what was bridged" request.)
- **Reverse geocoding accuracy**: lookups are restricted to real addresses/POIs and the match is verified to be *at* the queried point, so a business across the street or a neighbour's address no longer wins — the label degrades to the street instead. Cache is versioned so stale labels re-resolve.
- **No more apparent freezes**: removal, bulk removal, and revert keep the spinner up across the file rewrite *and* the re-render.
- **Update button states**: animates while downloading, turns orange and flashes when a restart is pending.
- **Zone marker icons** (20 Material Symbols) + a Map UI setting to hide zone markers; FSD marker letters (A/D) now centred from measured glyph bounds.
- **Bug fix**: `stream-json`'s `Assembler` export shape changed in the recent dependency bump, which broke the large-file streaming reader. The import now accepts both shapes so a future bump can't silently break it again.

## Why

Privacy zones and multi-select were the two remaining feature cards on the project board; the rest is polish and accuracy work that surfaced alongside them.

## Reviewer notes

- **Privacy**: zones live **only in `localStorage`** and are deliberately never written into `drive-data.json`, since that file is shared, exported, and imported between installs. Worth a look if you disagree with that boundary.
- **Parity**: no drive-stat math changed. Culling reuses the same WGS-84 `geodesicM` as the stats, against the grouper's snapped endpoints; `remove-drives` mirrors the single-drive removal semantics exactly (route-file matching, tag cleanup, atomic write).
- Bumped to **1.4.2**; the released 1.4.1 "Maintenance Update" section is preserved in the changelog.
- `npm test` → **60/60 pass**. The UI work (zone editor gestures, animations, marker centring) is not covered by tests and needs a runtime pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)